### PR TITLE
🧪 [TEST] 복수 좌석 잠금 순서와 deadlock 기준선

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -8,8 +8,8 @@ BACKLOG는 확정 구현 목록이 아니라 조사와 재현이 필요한 후�
 | 0-FE | FE | 독립 저장소의 작업 기록 기준이 없다 | BE 기준과 중복·차이를 조사한 FE Issue | BE Issue 한 개로 FE까지 수정 | 후보 |
 | 1 | BE | 예약 경합을 반복 재현할 기반이 없다 | Java 21, MariaDB Testcontainers, 외부 연동 비활성화, 명시적 fixture | 동시성 로직 개선 | 완료 ([#3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3), [PR #4](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/4)) |
 | 2 | BE | 동일 좌석 잠금과 서로 다른 좌석 집계·복수 좌석 rollback이 검증되지 않았다 | 동시 요청 성공 수, 예약 row, 좌석 상태, 잔여 수량 | 잠금 방식 선제 교체 | 기준선 완료 ([#3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3), [PR #4](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/4)) |
-| 3 | BE | 공통 회차 잔여 좌석 갱신 유실과 checked exception 부분 commit | 결정적 경합·중간 실패 fixture의 개선 후 불변식 | Redis·분산 락 | 진행 중 ([#5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5)) |
-| 4 | BE | 복수 좌석의 입력 순서가 달라 deadlock이 발생할 수 있다 | 반대 순서 fixture, DB deadlock과 rollback 기록 | 무제한 재시도 | 후보 |
+| 3 | BE | 공통 회차 잔여 좌석 갱신 유실과 checked exception 부분 commit | 결정적 경합·중간 실패 fixture의 개선 후 불변식 | Redis·분산 락 | 완료 ([#5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5), [PR #6](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/6)) |
+| 4 | BE | 복수 좌석의 입력 순서가 달라 deadlock이 발생할 수 있다 | 반대 순서 fixture, 첫 lock 동시 획득, DB 예외와 rollback 기록 | 무제한 재시도 | 기준선 완료 ([#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)): 현 schema에서는 첫 lock부터 직렬화 |
 | 5 | BE/FE | 예약과 결제 완료가 결합되고 상태 전이가 불명확하다 | 현재 흐름 재현, mock 결제, 허용·거부 전이 테스트 | 실제 결제 실행 | 후보 |
 | 6 | BE/FE | 예약·결제·취소 중복 요청의 결과가 안정적이지 않다 | 중복 key, 응답 유실, payload 충돌 fixture | 브로커 선제 도입 | 후보 |
 | 7 | BE | 고경합 병목 위치가 측정되지 않았다 | k6 TPS·p95·오류율, lock wait, Hikari, DB 자원 | 운영 SLA 주장 | 후보 |

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -13,7 +13,18 @@
 
 ## 진행 중
 
-없음.
+### Backend Issue #9 — 복수 좌석 잠금 순서와 deadlock 기준선
+
+- Issue: [#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
+- Branch: `test/#9-multi-seat-deadlock-baseline`
+- 상태: 구현·전체 검증 완료, PR 생성 전
+- 계획 승인: 완료
+- 구현: 완료
+- 검증: 반대 순서 기준선 3회와 전체 Testcontainers test invocation 12개 통과, `git diff --check` 통과
+- Reviewer: 대기
+- 사용자 merge 승인: 대기
+- 범위: 반대 순서 복수 좌석 transaction의 첫 lock 동기화, deadlock·예외·rollback·최종 재고 기준선
+- 제외: 운영 로직·lock ordering·인덱스·retry·임시 점유·결제·Frontend·부하 테스트와 분산 기술
 
 ## 완료
 

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -16,12 +16,13 @@
 ### Backend Issue #9 — 복수 좌석 잠금 순서와 deadlock 기준선
 
 - Issue: [#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
+- PR: [#10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10)
 - Branch: `test/#9-multi-seat-deadlock-baseline`
-- 상태: 구현·전체 검증 완료, PR 생성 전
+- 상태: PR 생성, Reviewer 검토 대기
 - 계획 승인: 완료
 - 구현: 완료
 - 검증: 반대 순서 기준선 3회와 전체 Testcontainers test invocation 12개 통과, `git diff --check` 통과
-- Reviewer: 대기
+- Reviewer: PR #10 최신 HEAD 검토 대기
 - 사용자 merge 승인: 대기
 - 범위: 반대 순서 복수 좌석 transaction의 첫 lock 동기화, deadlock·예외·rollback·최종 재고 기준선
 - 제외: 운영 로직·lock ordering·인덱스·retry·임시 점유·결제·Frontend·부하 테스트와 분산 기술

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -13,21 +13,23 @@
 
 ## 진행 중
 
+없음.
+
+## 완료
+
 ### Backend Issue #9 — 복수 좌석 잠금 순서와 deadlock 기준선
 
 - Issue: [#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
 - PR: [#10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10)
 - Branch: `test/#9-multi-seat-deadlock-baseline`
-- 상태: PR 생성, Reviewer 검토 대기
+- 상태: 완료
 - 계획 승인: 완료
 - 구현: 완료
 - 검증: 반대 순서 기준선 3회와 전체 Testcontainers test invocation 12개 통과, `git diff --check` 통과
-- Reviewer: PR #10 최신 HEAD 검토 대기
-- 사용자 merge 승인: 대기
+- Reviewer: 최종 검토 HEAD `97310c0`, Blocking 없음, Non-blocking 2건, `MERGE_READY: YES`
+- 사용자 최종 승인 후 2026-08-20 squash merge
 - 범위: 반대 순서 복수 좌석 transaction의 첫 lock 동기화, deadlock·예외·rollback·최종 재고 기준선
 - 제외: 운영 로직·lock ordering·인덱스·retry·임시 점유·결제·Frontend·부하 테스트와 분산 기술
-
-## 완료
 
 ### Backend Issue #7 — 백엔드 아키텍처 학습 기준선
 

--- a/docs/project-improvement/EVIDENCE_MAP.md
+++ b/docs/project-improvement/EVIDENCE_MAP.md
@@ -13,7 +13,7 @@
 | checked exception의 복수 좌석 부분 commit | Issue #3에서 첫 좌석·예약 commit | `rollbackFor = Exception.class` | `[A1, NOT-EXISTING]` 최종 DB 상태 | 좌석·예약 0, 잔여 24, 전체 rollback | [BE #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5) |
 | 잔여 수량 음수 방지 | 잔여 1, 예약 가능한 좌석 `A1`, `A2`의 guard fixture | `seatAmount >= seatCount` 조건과 영향 row 확인 | 실패 후 좌석·예약·집계 확인 | update 0행, 좌석·예약 0, 잔여 1 | [BE #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5) |
 | 좌석 잠금 조회의 복합 인덱스 부재 | 생성 schema `SHOW INDEX`, 잠금 SQL `EXPLAIN` | 운영 schema 변경 없음 | index column, access type, selected key | `seat_number` 미포함, `type=ALL`, `key=null`, fixture 24행 | [BE #3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3) |
-| 복수 좌석 반대 순서의 deadlock 가능성 | MariaDB 10.11.8, `[A1,A2]`·`[A2,A1]`, 첫 lock 반환 후 barrier, 3회 반복 | 운영 코드 변경 없음 | 첫 lock 동시 획득, SQL 예외, rollback, 좌석·예약·잔여 수량 | 3회 모두 첫 lock부터 직렬화, deadlock 없음, 성공 1·business 실패 1, 좌석·예약 2·잔여 22 | [BE #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9) |
+| 복수 좌석 반대 순서의 deadlock 가능성 | MariaDB 10.11.8, `[A1,A2]`·`[A2,A1]`, 첫 lock 반환 후 barrier, 3회 반복 | 운영 코드 변경 없음 | 첫 lock 동시 획득, SQL 예외, rollback, 좌석·예약·잔여 수량 | 3회 모두 첫 lock부터 직렬화, deadlock 없음, 성공 1·business 실패 1, 좌석·예약 2·잔여 22 | [BE #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9) / [PR #10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10) |
 | 예약·결제·취소 중복 요청 | 중복 key와 응답 유실 fixture 필요 | 미정 | 결과 재사용, 중복 row, 상태·재고 | 미측정 | 후속 Issue |
 
 ## 기록 규칙

--- a/docs/project-improvement/EVIDENCE_MAP.md
+++ b/docs/project-improvement/EVIDENCE_MAP.md
@@ -13,7 +13,7 @@
 | checked exception의 복수 좌석 부분 commit | Issue #3에서 첫 좌석·예약 commit | `rollbackFor = Exception.class` | `[A1, NOT-EXISTING]` 최종 DB 상태 | 좌석·예약 0, 잔여 24, 전체 rollback | [BE #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5) |
 | 잔여 수량 음수 방지 | 잔여 1, 예약 가능한 좌석 `A1`, `A2`의 guard fixture | `seatAmount >= seatCount` 조건과 영향 row 확인 | 실패 후 좌석·예약·집계 확인 | update 0행, 좌석·예약 0, 잔여 1 | [BE #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5) |
 | 좌석 잠금 조회의 복합 인덱스 부재 | 생성 schema `SHOW INDEX`, 잠금 SQL `EXPLAIN` | 운영 schema 변경 없음 | index column, access type, selected key | `seat_number` 미포함, `type=ALL`, `key=null`, fixture 24행 | [BE #3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3) |
-| 복수 좌석 잠금 순서의 deadlock 가능성 | `[A,B]`, `[B,A]` 동시 요청 | 미정 | deadlock, rollback, lock wait | 미측정 | 후속 Issue |
+| 복수 좌석 반대 순서의 deadlock 가능성 | MariaDB 10.11.8, `[A1,A2]`·`[A2,A1]`, 첫 lock 반환 후 barrier, 3회 반복 | 운영 코드 변경 없음 | 첫 lock 동시 획득, SQL 예외, rollback, 좌석·예약·잔여 수량 | 3회 모두 첫 lock부터 직렬화, deadlock 없음, 성공 1·business 실패 1, 좌석·예약 2·잔여 22 | [BE #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9) |
 | 예약·결제·취소 중복 요청 | 중복 key와 응답 유실 fixture 필요 | 미정 | 결과 재사용, 중복 row, 상태·재고 | 미측정 | 후속 Issue |
 
 ## 기록 규칙

--- a/docs/project-improvement/LEARNING_JOURNEY.md
+++ b/docs/project-improvement/LEARNING_JOURNEY.md
@@ -84,3 +84,23 @@ Issue #3에서 같은 예약 transaction 안의 두 결함을 분리해 확인�
 ### 링크
 
 - [Backend Issue #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5)
+
+## Issue #9 — 복수 좌석 잠금 순서와 deadlock 기준선
+
+### 관찰
+
+같은 회차의 `[A1,A2]`와 `[A2,A1]`을 동시에 예약하고, test 전용 Repository proxy에서 각 transaction의 첫 좌석 lock 반환 직후 barrier를 기다렸습니다. 세 번 모두 두 transaction이 서로 다른 첫 lock을 동시에 획득하지 못했고 SQL deadlock은 발생하지 않았습니다. 한 transaction이 두 좌석을 commit한 뒤 다른 transaction은 `이미 예약된 좌석입니다.`로 실패했습니다.
+
+### 해석
+
+이 결과는 입력 순서 잠금이 안전하다는 뜻이 아닙니다. 기존 `EXPLAIN`의 full scan과 복합 index 부재를 함께 보면 현재 잠금 조회가 첫 좌석부터 넓게 직렬화된 것으로 추론할 수 있습니다. 좌석 식별 index로 잠금 범위를 좁히면 반대 순서 cycle이 드러날 수 있으므로 index와 canonical lock ordering을 함께 비교해야 합니다.
+
+### 최종 상태
+
+매회 성공 1·business 실패 1, 예약 좌석 2, 예약 row 2, 잔여 22로 `24 = reserved + remaining`을 충족했습니다. 실패 transaction의 부분 commit과 SQL deadlock error는 없었습니다. 결과는 MariaDB 10.11.8 단일 컨테이너와 가상 좌석 24개 조건이며 운영 deadlock 발생률이나 처리량을 의미하지 않습니다.
+
+상세 동기화 방식과 다음 검증 조건은 [복수 좌석 잠금 순서와 deadlock 기준선](multi-seat-lock-order-deadlock-baseline.md)에 기록합니다.
+
+### 링크
+
+- [Backend Issue #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)

--- a/docs/project-improvement/LEARNING_JOURNEY.md
+++ b/docs/project-improvement/LEARNING_JOURNEY.md
@@ -104,3 +104,4 @@ Issue #3에서 같은 예약 transaction 안의 두 결함을 분리해 확인�
 ### 링크
 
 - [Backend Issue #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
+- [Backend PR #10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10)

--- a/docs/project-improvement/multi-seat-lock-order-deadlock-baseline.md
+++ b/docs/project-improvement/multi-seat-lock-order-deadlock-baseline.md
@@ -1,0 +1,103 @@
+# 복수 좌석 잠금 순서와 deadlock 기준선
+
+## 목적
+
+현재 `SeatReservationService.reserveSeat()`는 요청의 `seatNumberList` 순서대로 좌석을 `PESSIMISTIC_WRITE` 조회한다. 같은 회차에서 `[A1, A2]`와 `[A2, A1]`을 동시에 예약할 때 실제 MariaDB deadlock이 발생하는지, 발생하지 않는다면 어떤 잠금 동작 때문인지 운영 코드를 바꾸기 전에 고정한다.
+
+이 결과는 로컬 단일 JVM·MariaDB 10.11.8·가상 좌석 24개의 transaction 기준선이다. 실제 예매처 성능이나 운영 환경의 deadlock 발생률을 의미하지 않는다.
+
+## 선행 조건
+
+- Java 21
+- Spring Boot 3.2.5, Spring Data JPA
+- MariaDB Testcontainers `mariadb:10.11.8`
+- 공연 1개, 회차 1개
+- 좌석 `A1`~`C8` 24개, 모두 `reserved=false`
+- 회차 잔여 수량 `seatAmount=24`
+- MariaDB 기본 transaction 격리 설정
+- 운영 KOPIS·CoolSMS·OAuth·결제·운영 DB 호출 없음
+
+좌석 잠금 query 조건은 `concertTime.id`와 `seatNumber`지만 `(concert_time_id, seat_number)` 복합 인덱스와 유일 제약은 없다. Issue #3의 기존 `EXPLAIN` 기준선에서는 해당 `SELECT ... FOR UPDATE`가 `type=ALL`, 선택 index `null`이었다.
+
+## 시나리오
+
+두 개의 service transaction을 고정 thread pool에서 동시에 시작한다.
+
+```text
+Transaction 1: [A1, A2]
+Transaction 2: [A2, A1]
+```
+
+단순한 시작 latch만으로는 첫 transaction이 모든 좌석을 예약한 후 두 번째 transaction이 시작할 수 있어 잠금 순서를 검증할 수 없다. 따라서 test 전용 Repository proxy가 각 transaction의 첫 `findByConcertTimeIdAndSeatNumberWithLock()` 반환 직후 barrier를 기다린다.
+
+Repository 호출이 반환됐다는 것은 해당 transaction이 첫 좌석의 DB lock을 획득했다는 뜻이다. 두 transaction이 서로 다른 첫 lock을 모두 획득하면 barrier가 열리고 반대편 좌석을 요청해 순환 대기를 만들 수 있다.
+
+반대로 첫 잠금 조회 자체가 넓게 직렬화되면 한 transaction만 barrier에 도달한다. 이때 2초 후 barrier 대기를 끝내되 예외를 발생시키지 않고 transaction을 계속 진행한다. 따라서 probe 때문에 첫 transaction이 rollback되는 것을 막고 현재 서비스 결과를 그대로 관찰한다.
+
+## 관찰 결과
+
+한 test 실행 안에서 같은 시나리오를 3회 반복했다.
+
+| 반복 | 서로 다른 첫 lock 동시 획득 | 성공 | 실패 | SQL state / error code | 좌석 | 예약 | 잔여 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 아니요 | 1 | 1, `이미 예약된 좌석입니다.` | 없음 | 2 | 2 | 22 |
+| 2 | 아니요 | 1 | 1, `이미 예약된 좌석입니다.` | 없음 | 2 | 2 | 22 |
+| 3 | 아니요 | 1 | 1, `이미 예약된 좌석입니다.` | 없음 | 2 | 2 | 22 |
+
+세 번 모두 `firstLocksConcurrent=false`였고 deadlock SQL exception은 발생하지 않았다. 먼저 첫 lock을 얻은 transaction이 두 좌석을 예약하고 commit한 후, 대기하던 transaction은 자신의 첫 좌석 조회를 마치고 이미 예약된 상태를 확인해 business exception으로 실패했다.
+
+최종 상태는 매회 다음 불변식을 충족했다.
+
+```text
+reserved seats = 2
+reservation rows = 2
+remaining seats = 22
+24 = reserved seats + remaining seats
+```
+
+## 해석
+
+현재 schema와 query plan에서는 서로 반대 순서의 두 transaction이 각각 첫 좌석 lock을 동시에 보유하는 단계까지 도달하지 못했다. 따라서 이번 fixture에서는 순환 대기와 DB deadlock이 만들어지지 않았다.
+
+이는 `입력 순서대로 잠가도 안전하다`는 증명이 아니다. `seat_number`를 포함한 선택적 index가 없고 기존 query plan이 full scan인 사실을 함께 보면, 잠금 조회가 목표 좌석보다 넓은 범위를 잠가 같은 회차의 첫 요청부터 직렬화한 것으로 해석할 수 있다. 이 인과관계는 현재 관찰과 query plan에 기반한 추론이며 실제 lock row 범위 자체를 별도 계측한 결과는 아니다.
+
+현재 동작의 trade-off는 다음과 같다.
+
+- 장점처럼 보이는 결과: 반대 순서 transaction이 동시에 첫 lock을 보유하지 못해 이번 fixture에서 deadlock이 없음
+- 비용: 서로 다른 좌석 예약도 첫 잠금부터 대기할 수 있어 좌석 단위 동시성이 제한됨
+- 잠재 변화: 복합 index를 추가해 잠금 범위를 좁히면 서로 다른 첫 lock을 동시에 획득해 기존 입력 순서에서 deadlock cycle이 드러날 수 있음
+
+따라서 `deadlock이 관찰되지 않음`을 개선 완료나 고경합 처리 성능으로 표현하지 않는다.
+
+## 자동화한 회귀 조건
+
+`SeatReservationConcurrencyIntegrationTest.oppositeSeatOrderConcurrentReservationSerializesAtFirstLockWithoutDeadlock()`은 다음을 검증한다.
+
+1. `[A1,A2]`, `[A2,A1]` 두 요청 중 1개 성공
+2. 다른 1개는 SQL deadlock이 아니라 `이미 예약된 좌석입니다.`로 실패
+3. 두 transaction이 서로 다른 첫 좌석 lock을 동시에 획득하지 못함
+4. 실패 transaction에 부분 예약이 없음
+5. 좌석 2, 예약 2, 잔여 22
+6. 좌석·예약·집계 불변식 충족
+7. 같은 시나리오 3회 반복
+
+## 다음 Issue의 검증 순서
+
+복합 index와 lock ordering은 독립적으로 적용하면 해석이 왜곡될 수 있으므로 다음 순서로 함께 비교한다.
+
+1. 기존 데이터에서 `(concert_time_id, seat_number)` 중복 여부 확인
+2. 복합 unique index를 적용한 test schema에서 잠금 query plan 확인
+3. 입력 순서를 유지한 반대 순서 fixture로 deadlock이 드러나는지 확인
+4. 좌석 번호를 canonical order로 정렬한 뒤 같은 fixture 재실행
+5. 동일 좌석 1건 성공, 서로 다른 좌석의 동시 처리, 잔여 집계 회귀 확인
+6. migration과 운영 로직은 비교 근거가 확인된 뒤 별도 승인
+
+무제한 retry, Redis 분산 lock과 대기열은 이 기준선만으로 도입하지 않는다. 좌석 임시 점유는 결제 전 `AVAILABLE → HELD → RESERVED` 전이를 다루는 별도 상태 모델이며 이번 최종 예약 잠금 기준선에는 포함하지 않는다.
+
+## 연결
+
+- [Issue #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
+- [예매 transaction·경합 기준선](reservation-transaction-concurrency-baseline.md)
+- [예약 원자성·잔여 좌석 정합성 개선](reservation-atomicity-inventory-consistency.md)
+- [Backend 아키텍처 학습 기준선](backend-architecture-learning-baseline.md)
+- [Jakarta Persistence lock mode](https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#locking-and-concurrency)

--- a/docs/project-improvement/multi-seat-lock-order-deadlock-baseline.md
+++ b/docs/project-improvement/multi-seat-lock-order-deadlock-baseline.md
@@ -97,6 +97,7 @@ remaining seats = 22
 ## 연결
 
 - [Issue #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
+- [PR #10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10)
 - [예매 transaction·경합 기준선](reservation-transaction-concurrency-baseline.md)
 - [예약 원자성·잔여 좌석 정합성 개선](reservation-atomicity-inventory-consistency.md)
 - [Backend 아키텍처 학습 기준선](backend-architecture-learning-baseline.md)

--- a/onticket/src/test/java/com/onticket/concert/service/SeatReservationConcurrencyIntegrationTest.java
+++ b/onticket/src/test/java/com/onticket/concert/service/SeatReservationConcurrencyIntegrationTest.java
@@ -35,6 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -47,6 +48,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +72,9 @@ class SeatReservationConcurrencyIntegrationTest {
     private static final String CONCERT_ID = "BASELINE-CONCERT";
     private static final String USERNAME = "baseline-user";
     private static final AtomicReference<CyclicBarrier> AGGREGATE_READ_BARRIER = new AtomicReference<>();
+    private static final AtomicReference<CyclicBarrier> FIRST_SEAT_LOCK_BARRIER = new AtomicReference<>();
+    private static final AtomicBoolean BOTH_FIRST_SEAT_LOCKS_ACQUIRED = new AtomicBoolean();
+    private static final ThreadLocal<Integer> SEAT_LOCK_CALL_COUNT = ThreadLocal.withInitial(() -> 0);
 
     @Container
     static final MariaDBContainer<?> MARIA_DB = new MariaDBContainer<>("mariadb:10.11.8")
@@ -200,6 +206,51 @@ class SeatReservationConcurrencyIntegrationTest {
         assertThat(snapshot.inventoryEquationHolds()).isTrue();
     }
 
+    @RepeatedTest(3)
+    void oppositeSeatOrderConcurrentReservationSerializesAtFirstLockWithoutDeadlock() throws Exception {
+        FIRST_SEAT_LOCK_BARRIER.set(new CyclicBarrier(2));
+        BOTH_FIRST_SEAT_LOCKS_ACQUIRED.set(false);
+
+        List<LockAttemptResult> results;
+        try {
+            results = runRequestsConcurrently(List.of(
+                    List.of("A1", "A2"),
+                    List.of("A2", "A1")
+            ));
+        } finally {
+            FIRST_SEAT_LOCK_BARRIER.set(null);
+        }
+
+        InventorySnapshot snapshot = inventorySnapshot();
+
+        System.out.printf(
+                "OPPOSITE_ORDER_BASELINE firstLocksConcurrent=%s results=%s remaining=%d reserved=%d reservations=%d invariant=%s%n",
+                BOTH_FIRST_SEAT_LOCKS_ACQUIRED.get(),
+                results,
+                snapshot.remainingSeats(),
+                snapshot.successfullyReservedSeats(),
+                snapshot.reservations(),
+                snapshot.inventoryEquationHolds()
+        );
+
+        assertThat(results).hasSize(2);
+        assertThat(BOTH_FIRST_SEAT_LOCKS_ACQUIRED.get()).isFalse();
+        assertThat(results).filteredOn(LockAttemptResult::success).hasSize(1);
+        assertThat(results).filteredOn(result -> !result.success())
+                .hasSize(1)
+                .allSatisfy(result -> {
+                    assertThat(result.exceptionType()).isEqualTo("Exception");
+                    assertThat(result.message()).isEqualTo("이미 예약된 좌석입니다.");
+                    assertThat(result.sqlState()).isNull();
+                    assertThat(result.errorCode()).isNull();
+                });
+        assertThat(snapshot.successfullyReservedSeats()).isEqualTo(2);
+        assertThat(snapshot.reservations()).isEqualTo(2);
+        assertThat(snapshot.remainingSeats()).isEqualTo(TOTAL_SEATS - 2);
+        assertThat(snapshot.inventoryEquationHolds()).isTrue();
+        assertThat(snapshot.successfullyReservedSeats()).isEqualTo(snapshot.reservations());
+    }
+
     @Test
     void checkedFailureAfterFirstSeatRollsBackEntireReservation() {
         assertThatThrownBy(() -> seatReservationService.reserveSeat(
@@ -311,6 +362,54 @@ class SeatReservationConcurrencyIntegrationTest {
         }
     }
 
+    private List<LockAttemptResult> runRequestsConcurrently(List<List<String>> seatNumberRequests) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(seatNumberRequests.size());
+        CountDownLatch ready = new CountDownLatch(seatNumberRequests.size());
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<LockAttemptResult>> futures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < seatNumberRequests.size(); i++) {
+                String username = USERNAME + "-opposite-" + i;
+                List<String> seatNumbers = seatNumberRequests.get(i);
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    if (!start.await(5, TimeUnit.SECONDS)) {
+                        return LockAttemptResult.failure(
+                                new TimeoutException("동시 시작 신호 대기 시간 초과")
+                        );
+                    }
+
+                    try {
+                        seatReservationService.reserveSeat(
+                                username,
+                                CONCERT_ID,
+                                request(seatNumbers.toArray(String[]::new))
+                        );
+                        return LockAttemptResult.succeeded();
+                    } catch (Exception exception) {
+                        return LockAttemptResult.failure(exception);
+                    } finally {
+                        SEAT_LOCK_CALL_COUNT.remove();
+                    }
+                }));
+            }
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            List<LockAttemptResult> results = new ArrayList<>();
+            for (Future<LockAttemptResult> future : futures) {
+                results.add(future.get(20, TimeUnit.SECONDS));
+            }
+            return results;
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
     private ReservRequest request(String... seatNumbers) {
         ReservRequest request = new ReservRequest();
         request.setConcertTimeId(concertTimeId);
@@ -384,6 +483,40 @@ class SeatReservationConcurrencyIntegrationTest {
         }
     }
 
+    private record LockAttemptResult(
+            boolean success,
+            String exceptionType,
+            String message,
+            String sqlState,
+            Integer errorCode
+    ) {
+        static LockAttemptResult succeeded() {
+            return new LockAttemptResult(true, null, null, null, null);
+        }
+
+        static LockAttemptResult failure(Throwable throwable) {
+            SQLException sqlException = findSqlException(throwable);
+            return new LockAttemptResult(
+                    false,
+                    throwable.getClass().getSimpleName(),
+                    throwable.getMessage(),
+                    sqlException == null ? null : sqlException.getSQLState(),
+                    sqlException == null ? null : sqlException.getErrorCode()
+            );
+        }
+
+        private static SQLException findSqlException(Throwable throwable) {
+            Throwable current = throwable;
+            while (current != null) {
+                if (current instanceof SQLException sqlException) {
+                    return sqlException;
+                }
+                current = current.getCause();
+            }
+            return null;
+        }
+    }
+
     private record InventorySnapshot(int remainingSeats, long successfullyReservedSeats, long reservations) {
         boolean inventoryEquationHolds() {
             return TOTAL_SEATS == remainingSeats + successfullyReservedSeats;
@@ -413,11 +546,34 @@ class SeatReservationConcurrencyIntegrationTest {
                                     }
                                 }
 
+                                Object result;
                                 try {
-                                    return method.invoke(seatRepository, args);
+                                    result = method.invoke(seatRepository, args);
                                 } catch (InvocationTargetException exception) {
                                     throw exception.getCause();
                                 }
+
+                                if (method.getName().equals("findByConcertTimeIdAndSeatNumberWithLock")) {
+                                    CyclicBarrier barrier = FIRST_SEAT_LOCK_BARRIER.get();
+                                    if (barrier != null) {
+                                        int lockCallCount = SEAT_LOCK_CALL_COUNT.get() + 1;
+                                        SEAT_LOCK_CALL_COUNT.set(lockCallCount);
+                                        if (lockCallCount != 1) {
+                                            return result;
+                                        }
+
+                                        try {
+                                            barrier.await(2, TimeUnit.SECONDS);
+                                            BOTH_FIRST_SEAT_LOCKS_ACQUIRED.set(true);
+                                        } catch (TimeoutException ignored) {
+                                            // 첫 lock 조회 자체가 넓게 직렬화되면 transaction을 실패시키지 않고 계속 진행한다.
+                                        } catch (java.util.concurrent.BrokenBarrierException ignored) {
+                                            // 상대 transaction의 timeout 이후 도달한 경우에도 현재 동작 관찰을 계속한다.
+                                        }
+                                    }
+                                }
+
+                                return result;
                             }
                     );
                 }


### PR DESCRIPTION
## 📌 목적 (Why)

- 복수 좌석을 반대 순서로 예약할 때 현재 MariaDB 잠금 동작과 deadlock 발생 여부를 운영 로직 변경 전에 고정합니다.
- Closes #9

## 🧩 범위 (Scope)

- `[A1,A2]`, `[A2,A1]` 동시 예약과 첫 좌석 lock 획득 후 test barrier
- 성공·실패·SQL 예외·rollback·최종 재고 검증
- 기준선 결과와 후속 index·canonical lock ordering 검증 조건 문서화
- 진행·학습·근거·BACKLOG 갱신

## ✅ 작업 항목 (Todo)

- [x] 첫 좌석 lock 동시 획득 여부를 관찰하는 test probe 구성
- [x] 반대 순서 시나리오 3회 반복
- [x] SQL deadlock과 business 실패 구분
- [x] 좌석·예약·잔여 수량 불변식 검증

## 🧾 완료 기준 (Definition of Done)

- [x] 애플리케이션 운영 로직을 변경하지 않았습니다.
- [x] 현 schema에서는 첫 lock부터 직렬화되어 deadlock cycle이 생기지 않음을 확인했습니다.
- [x] 매회 성공 1·business 실패 1, 좌석·예약 2·잔여 22를 확인했습니다.
- [x] 무제한 retry·분산 lock·대기열을 도입하지 않았습니다.

## 🧪 테스트/검증 계획

- [x] 전체 Gradle Testcontainers test invocation 12개 통과
- [x] 반대 순서 기준선 3회 동일 결과
- [x] `git diff --check` 통과
- [x] 외부 API·결제·운영 데이터 미호출

## 🔗 참고 (선택)

- Issue #3 동시성 기준선
- Issue #5 예약 원자성·잔여 좌석 정합성 개선
- Issue #7 Backend 아키텍처 학습 기준선
