### PR TITLE
🧪 [TEST] 좌석 복합 인덱스와 deadlock 비교 기준선

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,7 @@ BACKLOG는 확정 구현 목록이 아니라 조사와 재현이 필요한 후�
 | 1 | BE | 예약 경합을 반복 재현할 기반이 없다 | Java 21, MariaDB Testcontainers, 외부 연동 비활성화, 명시적 fixture | 동시성 로직 개선 | 완료 ([#3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3), [PR #4](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/4)) |
 | 2 | BE | 동일 좌석 잠금과 서로 다른 좌석 집계·복수 좌석 rollback이 검증되지 않았다 | 동시 요청 성공 수, 예약 row, 좌석 상태, 잔여 수량 | 잠금 방식 선제 교체 | 기준선 완료 ([#3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3), [PR #4](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/4)) |
 | 3 | BE | 공통 회차 잔여 좌석 갱신 유실과 checked exception 부분 commit | 결정적 경합·중간 실패 fixture의 개선 후 불변식 | Redis·분산 락 | 완료 ([#5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5), [PR #6](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/6)) |
-| 4 | BE | 복수 좌석의 입력 순서가 달라 deadlock이 발생할 수 있다 | 반대 순서 fixture, 첫 lock 동시 획득, DB 예외와 rollback 기록 | 무제한 재시도 | 기준선 완료 ([#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)): 현 schema에서는 첫 lock부터 직렬화 |
+| 4 | BE | 복수 좌석의 입력 순서가 달라 deadlock이 발생할 수 있다 | 반대 순서 fixture, index 전후 query plan·첫 lock·DB 예외와 rollback | 무제한 재시도 | 비교 기준선 완료 ([#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9), [#11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)): index 적용 시 `1213/40001` 재현 |
 | 5 | BE/FE | 예약과 결제 완료가 결합되고 상태 전이가 불명확하다 | 현재 흐름 재현, mock 결제, 허용·거부 전이 테스트 | 실제 결제 실행 | 후보 |
 | 6 | BE/FE | 예약·결제·취소 중복 요청의 결과가 안정적이지 않다 | 중복 key, 응답 유실, payload 충돌 fixture | 브로커 선제 도입 | 후보 |
 | 7 | BE | 고경합 병목 위치가 측정되지 않았다 | k6 TPS·p95·오류율, lock wait, Hikari, DB 자원 | 운영 SLA 주장 | 후보 |

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -16,8 +16,9 @@
 ### Backend Issue #11 — 좌석 복합 인덱스와 deadlock 비교 기준선
 
 - Issue: [#11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)
+- PR: [#12](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/12)
 - Branch: `test/#11-seat-index-deadlock-comparison`
-- 상태: 비교 테스트·문서 구현 및 전체 검증 완료, PR 생성 전
+- 상태: PR 생성 및 전체 검증 완료, Reviewer 검토 전
 - 계획 승인: 완료
 - 구현: 완료
 - 검증: indexed 반대 순서 시나리오 3회 모두 `1213/40001` deadlock·victim rollback 확인, 전체 Testcontainers test invocation 16개 통과, `git diff --check` 통과

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -13,7 +13,16 @@
 
 ## 진행 중
 
-없음.
+### Backend Issue #11 — 좌석 복합 인덱스와 deadlock 비교 기준선
+
+- Issue: [#11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)
+- Branch: `test/#11-seat-index-deadlock-comparison`
+- 상태: 비교 테스트·문서 구현 및 전체 검증 완료, PR 생성 전
+- 계획 승인: 완료
+- 구현: 완료
+- 검증: indexed 반대 순서 시나리오 3회 모두 `1213/40001` deadlock·victim rollback 확인, 전체 Testcontainers test invocation 16개 통과, `git diff --check` 통과
+- 범위: test schema 복합 unique index, 잠금 query plan, 첫 lock 동시 획득, 반대 순서 deadlock·rollback·최종 재고 비교
+- 제외: 운영 Entity·schema·예약 로직, Flyway, retry·분산 lock·대기열, 임시 점유·결제·Frontend·부하 테스트
 
 ## 완료
 

--- a/docs/project-improvement/EVIDENCE_MAP.md
+++ b/docs/project-improvement/EVIDENCE_MAP.md
@@ -14,6 +14,7 @@
 | 잔여 수량 음수 방지 | 잔여 1, 예약 가능한 좌석 `A1`, `A2`의 guard fixture | `seatAmount >= seatCount` 조건과 영향 row 확인 | 실패 후 좌석·예약·집계 확인 | update 0행, 좌석·예약 0, 잔여 1 | [BE #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5) |
 | 좌석 잠금 조회의 복합 인덱스 부재 | 생성 schema `SHOW INDEX`, 잠금 SQL `EXPLAIN` | 운영 schema 변경 없음 | index column, access type, selected key | `seat_number` 미포함, `type=ALL`, `key=null`, fixture 24행 | [BE #3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3) |
 | 복수 좌석 반대 순서의 deadlock 가능성 | MariaDB 10.11.8, `[A1,A2]`·`[A2,A1]`, 첫 lock 반환 후 barrier, 3회 반복 | 운영 코드 변경 없음 | 첫 lock 동시 획득, SQL 예외, rollback, 좌석·예약·잔여 수량 | 3회 모두 첫 lock부터 직렬화, deadlock 없음, 성공 1·business 실패 1, 좌석·예약 2·잔여 22 | [BE #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9) / [PR #10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10) |
+| 좌석 복합 index 적용 시 잠금·deadlock 변화 | 같은 fixture에 `(concert_time_id, seat_number)` test unique index 적용 | 운영 코드·schema 변경 없음 | EXPLAIN, 첫 lock barrier, 반대 순서 3회, SQL state·error code, 사용자별 예약 row | `ALL/key=null`→`const/복합 key/rows=1`, 첫 lock 동시 획득, 3회 모두 `1213/40001`, victim 예약 0·최종 좌석/예약 2·잔여 22 | [BE #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11) |
 | 예약·결제·취소 중복 요청 | 중복 key와 응답 유실 fixture 필요 | 미정 | 결과 재사용, 중복 row, 상태·재고 | 미측정 | 후속 Issue |
 
 ## 기록 규칙

--- a/docs/project-improvement/EVIDENCE_MAP.md
+++ b/docs/project-improvement/EVIDENCE_MAP.md
@@ -14,7 +14,7 @@
 | 잔여 수량 음수 방지 | 잔여 1, 예약 가능한 좌석 `A1`, `A2`의 guard fixture | `seatAmount >= seatCount` 조건과 영향 row 확인 | 실패 후 좌석·예약·집계 확인 | update 0행, 좌석·예약 0, 잔여 1 | [BE #5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5) |
 | 좌석 잠금 조회의 복합 인덱스 부재 | 생성 schema `SHOW INDEX`, 잠금 SQL `EXPLAIN` | 운영 schema 변경 없음 | index column, access type, selected key | `seat_number` 미포함, `type=ALL`, `key=null`, fixture 24행 | [BE #3](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/3) |
 | 복수 좌석 반대 순서의 deadlock 가능성 | MariaDB 10.11.8, `[A1,A2]`·`[A2,A1]`, 첫 lock 반환 후 barrier, 3회 반복 | 운영 코드 변경 없음 | 첫 lock 동시 획득, SQL 예외, rollback, 좌석·예약·잔여 수량 | 3회 모두 첫 lock부터 직렬화, deadlock 없음, 성공 1·business 실패 1, 좌석·예약 2·잔여 22 | [BE #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9) / [PR #10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10) |
-| 좌석 복합 index 적용 시 잠금·deadlock 변화 | 같은 fixture에 `(concert_time_id, seat_number)` test unique index 적용 | 운영 코드·schema 변경 없음 | EXPLAIN, 첫 lock barrier, 반대 순서 3회, SQL state·error code, 사용자별 예약 row | `ALL/key=null`→`const/복합 key/rows=1`, 첫 lock 동시 획득, 3회 모두 `1213/40001`, victim 예약 0·최종 좌석/예약 2·잔여 22 | [BE #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11) |
+| 좌석 복합 index 적용 시 잠금·deadlock 변화 | 같은 fixture에 `(concert_time_id, seat_number)` test unique index 적용 | 운영 코드·schema 변경 없음 | EXPLAIN, 첫 lock barrier, 반대 순서 3회, SQL state·error code, 사용자별 예약 row | `ALL/key=null`→`const/복합 key/rows=1`, 첫 lock 동시 획득, 3회 모두 `1213/40001`, victim 예약 0·최종 좌석/예약 2·잔여 22 | [BE #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11), [PR #12](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/12) |
 | 예약·결제·취소 중복 요청 | 중복 key와 응답 유실 fixture 필요 | 미정 | 결과 재사용, 중복 row, 상태·재고 | 미측정 | 후속 Issue |
 
 ## 기록 규칙

--- a/docs/project-improvement/LEARNING_JOURNEY.md
+++ b/docs/project-improvement/LEARNING_JOURNEY.md
@@ -105,3 +105,23 @@ Issue #3에서 같은 예약 transaction 안의 두 결함을 분리해 확인�
 
 - [Backend Issue #9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9)
 - [Backend PR #10](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/10)
+
+## Issue #11 — 좌석 복합 인덱스와 deadlock 비교 기준선
+
+### 비교
+
+Issue #9와 같은 fixture에 test용 `(concert_time_id, seat_number)` 복합 unique index만 적용했습니다. 잠금 query plan은 `ALL/key=null`에서 `const/복합 key/rows=1`로 바뀌었고, 반대 순서 transaction은 서로 다른 첫 좌석 lock을 동시에 획득했습니다.
+
+### 관찰
+
+`[A1,A2]`와 `[A2,A1]` 시나리오를 3회 반복한 결과 매회 MariaDB error `1213`, SQL state `40001`이 발생했고 Spring은 `CannotAcquireLockException`으로 변환했습니다. 한 transaction만 성공했으며 deadlock victim 사용자의 예약 row는 0개였습니다. 최종 좌석 2·예약 2·잔여 22로 rollback 후 불변식은 유지됐습니다.
+
+### 다음 결정
+
+복합 index는 좌석 식별과 잠금 query plan을 개선하지만 입력 순서 잠금의 cycle을 실제로 드러냈습니다. 따라서 운영 변경에서는 index migration과 canonical lock ordering을 함께 검증해야 합니다. retry·분산 lock·대기열은 도입하지 않습니다.
+
+상세 조건은 [좌석 복합 인덱스와 deadlock 비교 기준선](seat-composite-index-deadlock-comparison.md)에 기록합니다.
+
+### 링크
+
+- [Backend Issue #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)

--- a/docs/project-improvement/LEARNING_JOURNEY.md
+++ b/docs/project-improvement/LEARNING_JOURNEY.md
@@ -125,3 +125,4 @@ Issue #9와 같은 fixture에 test용 `(concert_time_id, seat_number)` 복합 un
 ### 링크
 
 - [Backend Issue #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)
+- [Backend PR #12](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/12)

--- a/docs/project-improvement/seat-composite-index-deadlock-comparison.md
+++ b/docs/project-improvement/seat-composite-index-deadlock-comparison.md
@@ -1,0 +1,111 @@
+# 좌석 복합 인덱스와 deadlock 비교 기준선
+
+## 목적
+
+Issue #9에서는 `(concert_time_id, seat_number)` 복합 인덱스가 없는 현재 schema에서 반대 순서 복수 좌석 예약이 첫 잠금부터 직렬화되어 deadlock cycle에 도달하지 못했다. 이번 기준선은 같은 MariaDB fixture에 test용 복합 unique index만 적용해 query plan, 좌석 단위 잠금 동시성, deadlock과 rollback 결과가 어떻게 달라지는지 비교한다.
+
+운영 Entity·schema·예약 Service는 변경하지 않는다. 결과는 로컬 단일 JVM·MariaDB 10.11.8·가상 좌석 24개의 비교 실험이며 운영 deadlock 발생률이나 처리량을 의미하지 않는다.
+
+## 비교 조건
+
+- Java 21, Spring Boot 3.2.5
+- MariaDB Testcontainers `mariadb:10.11.8`
+- 공연 1개, 회차 1개, 가상 좌석 `A1`~`C8` 24개
+- `SeatReservationService.reserveSeat()`와 `PESSIMISTIC_WRITE` query는 동일
+- 요청 1: `[A1, A2]`
+- 요청 2: `[A2, A1]`
+- 각 transaction의 첫 좌석 잠금 query 반환 직후 test barrier 적용
+- indexed 시나리오는 3회 반복
+- KOPIS·CoolSMS·OAuth·결제·운영 DB 호출 없음
+
+비교를 위해 test schema에만 다음 index를 생성한다.
+
+```sql
+CREATE UNIQUE INDEX uk_seat_concert_time_number
+ON seat (concert_time_id, seat_number);
+```
+
+각 indexed test가 끝나면 외래 키용 `concert_time_id` 단일 보조 index를 복원한 뒤 복합 index를 제거한다. InnoDB는 복합 index의 선두 column을 외래 키 지원에 재사용하면서 기존 암시적 단일 index를 제거할 수 있으므로, 보조 index 복원 없이 복합 index를 drop하면 MariaDB error 1553이 발생한다.
+
+## query plan 비교
+
+동일한 잠금 SQL을 비교했다.
+
+```sql
+EXPLAIN
+SELECT *
+FROM seat
+WHERE concert_time_id = ?
+  AND seat_number = ?
+FOR UPDATE;
+```
+
+| 조건 | type | key | 예상 검사 rows |
+| --- | --- | --- | --- |
+| 복합 index 없음 | `ALL` | `null` | fixture 전체 |
+| 복합 unique index | `const` | `uk_seat_concert_time_number` | `1` |
+
+복합 index의 column 순서도 `concert_time_id`, `seat_number`로 확인했다. 이는 한 회차의 좌석 번호를 단일 row로 식별할 수 있음을 뜻하며, 실제 query가 해당 index를 선택했다.
+
+## 잠금·deadlock 비교
+
+| 조건 | 첫 좌석 lock 동시 획득 | 두 번째 잠금 결과 | 성공/실패 | 최종 상태 |
+| --- | --- | --- | --- | --- |
+| 복합 index 없음 | 3회 모두 `false` | SQL deadlock 없음, commit 후 business conflict | 성공 1 / `이미 예약된 좌석` 1 | 좌석 2, 예약 2, 잔여 22 |
+| 복합 unique index | 3회 모두 `true` | 3회 모두 DB deadlock | 성공 1 / deadlock victim 1 | 좌석 2, 예약 2, 잔여 22 |
+
+indexed fixture에서 MariaDB와 Spring이 반환한 실패 정보는 세 번 모두 같았다.
+
+```text
+Spring exception: CannotAcquireLockException
+SQL state:        40001
+MariaDB code:     1213
+message:          Deadlock found when trying to get lock
+```
+
+복합 index가 없을 때는 두 transaction이 서로 다른 첫 좌석 lock을 동시에 보유하지 못했다. 복합 index를 적용하자 각 query가 목표 row를 식별해 `A1`과 `A2`의 첫 잠금을 동시에 획득했고, 입력 순서가 반대인 두 번째 잠금에서 순환 대기가 만들어졌다.
+
+## rollback과 최종 불변식
+
+deadlock victim은 두 번째 좌석 query에서 실패하기 전에 첫 좌석 변경과 예약 저장을 진행할 수 있다. 테스트는 결과 순서에 대응하는 username별 예약 row를 다시 조회한다.
+
+- 성공 transaction 사용자: 예약 row 2개
+- deadlock victim 사용자: 예약 row 0개
+- 최종 예약 좌석: 2개
+- 전체 예약 row: 2개
+- 최종 잔여 수량: 22
+- `24 = reserved + remaining` 충족
+
+따라서 MariaDB가 victim transaction을 rollback하고 Spring transaction 경계가 부분 예약을 남기지 않는 것을 확인했다. 이 결과는 deadlock 자체를 허용해도 된다는 뜻이 아니다. 한 요청이 실패했고 client가 어떤 재시도 정책을 가져야 하는지도 정의되지 않았다.
+
+## 해석
+
+복합 unique index는 두 가지 효과를 함께 만든다.
+
+1. 한 회차의 같은 좌석 번호 중복을 DB에서 금지할 수 있다.
+2. 잠금 query가 목표 row를 직접 찾아 서로 다른 좌석 transaction의 불필요한 직렬화를 줄일 수 있다.
+
+동시에 기존 입력 순서 잠금의 잠재 deadlock을 실제로 드러냈다. 따라서 index만 단독 배포하면 query plan은 개선되지만 반대 순서 복수 좌석 요청에서 error 1213이 발생할 수 있다.
+
+현재 근거가 지지하는 다음 변경은 `복합 unique index + canonical lock ordering`을 같은 migration·Service 개선 범위에서 검증하는 것이다. 모든 요청이 좌석 번호를 정렬하고 같은 순서로 잠그면 반대 입력 payload도 동일한 lock 순서를 사용하므로 순환 대기의 한 조건을 제거할 수 있다.
+
+## 다음 개선 Issue의 완료 조건
+
+1. migration 전 기존 `(concert_time_id, seat_number)` 중복 검사
+2. Flyway 또는 명시적 migration으로 복합 unique index 생성
+3. null·빈 목록·payload 내 중복 좌석 validation
+4. 요청 원본과 무관한 canonical seat order 결정
+5. `[A1,A2]`, `[A2,A1]` indexed fixture에서 deadlock 0건
+6. 동일 좌석은 계속 1개 요청만 성공
+7. 서로 다른 좌석 예약과 잔여 집계 회귀 유지
+8. 실패 응답·retry 정책은 별도 API 계약으로 명시
+
+무제한 retry, Redis 분산 lock과 대기열은 이번 비교 결과만으로 도입하지 않는다. 좌석 임시 점유는 결제 전 상태 전이를 다루는 후속 도메인 작업이다.
+
+## 연결
+
+- [Issue #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)
+- [복수 좌석 잠금 순서와 deadlock 기준선](multi-seat-lock-order-deadlock-baseline.md)
+- [예약 원자성·잔여 좌석 정합성 개선](reservation-atomicity-inventory-consistency.md)
+- [개선 근거 연결표](EVIDENCE_MAP.md)
+- [MariaDB InnoDB foreign keys](https://mariadb.com/kb/en/foreign-keys/)

--- a/docs/project-improvement/seat-composite-index-deadlock-comparison.md
+++ b/docs/project-improvement/seat-composite-index-deadlock-comparison.md
@@ -105,6 +105,7 @@ deadlock victim은 두 번째 좌석 query에서 실패하기 전에 첫 좌석 
 ## 연결
 
 - [Issue #11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11)
+- [PR #12](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/12)
 - [복수 좌석 잠금 순서와 deadlock 기준선](multi-seat-lock-order-deadlock-baseline.md)
 - [예약 원자성·잔여 좌석 정합성 개선](reservation-atomicity-inventory-consistency.md)
 - [개선 근거 연결표](EVIDENCE_MAP.md)

--- a/onticket/src/test/java/com/onticket/concert/service/SeatReservationConcurrencyIntegrationTest.java
+++ b/onticket/src/test/java/com/onticket/concert/service/SeatReservationConcurrencyIntegrationTest.java
@@ -3,6 +3,7 @@ package com.onticket.concert.service;
 import com.onticket.concert.domain.Concert;
 import com.onticket.concert.domain.ConcertDetail;
 import com.onticket.concert.domain.ConcertTime;
+import com.onticket.concert.domain.Reservation;
 import com.onticket.concert.domain.Seat;
 import com.onticket.concert.dto.ReservRequest;
 import com.onticket.concert.repository.ConcertDetailRepository;
@@ -71,6 +72,8 @@ class SeatReservationConcurrencyIntegrationTest {
     private static final int TOTAL_SEATS = 24;
     private static final String CONCERT_ID = "BASELINE-CONCERT";
     private static final String USERNAME = "baseline-user";
+    private static final String SEAT_COMPOSITE_UNIQUE_INDEX = "uk_seat_concert_time_number";
+    private static final String SEAT_FOREIGN_KEY_SUPPORT_INDEX = "idx_seat_concert_time_test_restore";
     private static final AtomicReference<CyclicBarrier> AGGREGATE_READ_BARRIER = new AtomicReference<>();
     private static final AtomicReference<CyclicBarrier> FIRST_SEAT_LOCK_BARRIER = new AtomicReference<>();
     private static final AtomicBoolean BOTH_FIRST_SEAT_LOCKS_ACQUIRED = new AtomicBoolean();
@@ -251,6 +254,51 @@ class SeatReservationConcurrencyIntegrationTest {
         assertThat(snapshot.successfullyReservedSeats()).isEqualTo(snapshot.reservations());
     }
 
+    @RepeatedTest(3)
+    void indexedOppositeSeatOrderConcurrentReservationProducesDeadlockAndRollsBackVictim() throws Exception {
+        createSeatCompositeUniqueIndex();
+        FIRST_SEAT_LOCK_BARRIER.set(new CyclicBarrier(2));
+        BOTH_FIRST_SEAT_LOCKS_ACQUIRED.set(false);
+
+        List<LockAttemptResult> results;
+        try {
+            results = runRequestsConcurrently(List.of(
+                    List.of("A1", "A2"),
+                    List.of("A2", "A1")
+            ));
+        } finally {
+            FIRST_SEAT_LOCK_BARRIER.set(null);
+            dropSeatCompositeUniqueIndex();
+        }
+
+        InventorySnapshot snapshot = inventorySnapshot();
+
+        System.out.printf(
+                "INDEXED_OPPOSITE_ORDER_BASELINE firstLocksConcurrent=%s results=%s remaining=%d reserved=%d reservations=%d invariant=%s%n",
+                BOTH_FIRST_SEAT_LOCKS_ACQUIRED.get(),
+                results,
+                snapshot.remainingSeats(),
+                snapshot.successfullyReservedSeats(),
+                snapshot.reservations(),
+                snapshot.inventoryEquationHolds()
+        );
+
+        assertThat(BOTH_FIRST_SEAT_LOCKS_ACQUIRED.get()).isTrue();
+        assertThat(results).filteredOn(LockAttemptResult::success).hasSize(1);
+        assertThat(results).filteredOn(result -> !result.success())
+                .hasSize(1)
+                .allSatisfy(result -> {
+                    assertThat(result.exceptionType()).isEqualTo("CannotAcquireLockException");
+                    assertThat(result.sqlState()).isEqualTo("40001");
+                    assertThat(result.errorCode()).isEqualTo(1213);
+                });
+        assertReservationsMatchAttemptResults(results);
+        assertThat(snapshot.successfullyReservedSeats()).isEqualTo(2);
+        assertThat(snapshot.reservations()).isEqualTo(2);
+        assertThat(snapshot.remainingSeats()).isEqualTo(TOTAL_SEATS - 2);
+        assertThat(snapshot.inventoryEquationHolds()).isTrue();
+    }
+
     @Test
     void checkedFailureAfterFirstSeatRollsBackEntireReservation() {
         assertThatThrownBy(() -> seatReservationService.reserveSeat(
@@ -320,6 +368,40 @@ class SeatReservationConcurrencyIntegrationTest {
         assertThat(explain).hasSize(1);
         assertThat(explain.getFirst().get("type")).isEqualTo("ALL");
         assertThat(explain.getFirst().get("key")).isNull();
+    }
+
+    @Test
+    void compositeUniqueIndexChangesSeatLockQueryPlan() {
+        createSeatCompositeUniqueIndex();
+
+        try {
+            List<Map<String, Object>> indexes = jdbcTemplate.queryForList("SHOW INDEX FROM seat");
+            List<String> compositeIndexColumns = indexes.stream()
+                    .filter(row -> SEAT_COMPOSITE_UNIQUE_INDEX.equals(row.get("Key_name")))
+                    .sorted(Comparator.comparingInt(row -> ((Number) row.get("Seq_in_index")).intValue()))
+                    .map(row -> String.valueOf(row.get("Column_name")))
+                    .toList();
+
+            List<Map<String, Object>> explain = jdbcTemplate.queryForList(
+                    "EXPLAIN SELECT * FROM seat WHERE concert_time_id = ? AND seat_number = ? FOR UPDATE",
+                    concertTimeId,
+                    "A1"
+            );
+
+            System.out.printf(
+                    "SEAT_COMPOSITE_INDEX columns=%s explain=%s%n",
+                    compositeIndexColumns,
+                    explain
+            );
+
+            assertThat(compositeIndexColumns).containsExactly("concert_time_id", "seat_number");
+            assertThat(explain).hasSize(1);
+            assertThat(explain.getFirst().get("type")).isEqualTo("const");
+            assertThat(explain.getFirst().get("key")).isEqualTo(SEAT_COMPOSITE_UNIQUE_INDEX);
+            assertThat(Integer.parseInt(String.valueOf(explain.getFirst().get("rows")))).isEqualTo(1);
+        } finally {
+            dropSeatCompositeUniqueIndex();
+        }
     }
 
     private List<AttemptResult> runConcurrently(List<String> seatNumbers) throws Exception {
@@ -415,6 +497,39 @@ class SeatReservationConcurrencyIntegrationTest {
         request.setConcertTimeId(concertTimeId);
         request.setSeatNumberList(List.of(seatNumbers));
         return request;
+    }
+
+    private void createSeatCompositeUniqueIndex() {
+        jdbcTemplate.execute("""
+                CREATE UNIQUE INDEX %s
+                ON seat (concert_time_id, seat_number)
+                """.formatted(SEAT_COMPOSITE_UNIQUE_INDEX));
+    }
+
+    private void dropSeatCompositeUniqueIndex() {
+        boolean supportIndexExists = jdbcTemplate.queryForList("SHOW INDEX FROM seat").stream()
+                .anyMatch(row -> SEAT_FOREIGN_KEY_SUPPORT_INDEX.equals(row.get("Key_name")));
+        if (!supportIndexExists) {
+            jdbcTemplate.execute("""
+                    CREATE INDEX %s
+                    ON seat (concert_time_id)
+                    """.formatted(SEAT_FOREIGN_KEY_SUPPORT_INDEX));
+        }
+        jdbcTemplate.execute("DROP INDEX %s ON seat".formatted(SEAT_COMPOSITE_UNIQUE_INDEX));
+    }
+
+    private void assertReservationsMatchAttemptResults(List<LockAttemptResult> results) {
+        for (int i = 0; i < results.size(); i++) {
+            String username = USERNAME + "-opposite-" + i;
+            List<Reservation> reservations = reservationRepository.findByUsername(username)
+                    .orElseGet(List::of);
+
+            if (results.get(i).success()) {
+                assertThat(reservations).hasSize(2);
+            } else {
+                assertThat(reservations).isEmpty();
+            }
+        }
     }
 
     private Long createFixture() {


### PR DESCRIPTION
## 🚀 관련 이슈

- Closes #11

## 🧭 변경 타입

- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용

- test schema에 `(concert_time_id, seat_number)` 복합 unique index를 적용한 비교 시나리오를 추가했습니다.
- 무인덱스/인덱스 조건의 EXPLAIN과 반대 순서 복수 좌석 잠금 결과를 문서화했습니다.
- 운영 Entity·schema·예약 Service·Frontend는 변경하지 않았습니다.

## 🔍 기술적 배경

- 무인덱스에서는 잠금 쿼리가 `ALL/key=null`로 실행되어 첫 좌석 잠금이 직렬화됐습니다.
- 복합 인덱스 적용 후 `const/uk_seat_concert_time_number/rows=1`로 변경됐고, `[A1,A2]`·`[A2,A1]` 요청에서 실제 deadlock이 드러났습니다.
- 이 결과는 MariaDB 10.11.8과 가상 좌석 24개의 test fixture 기준이며 운영 발생률이나 성능으로 일반화하지 않습니다.

## 🧪 테스트/검증 (필수)

- [x] indexed 반대 순서 시나리오 3회 모두 `1213/40001` deadlock 재현
- [x] victim 예약 0건, 성공 예약 2건, 최종 좌석 2·예약 2·잔여 22 검증
- [x] `./gradlew test`: Testcontainers test invocation 16개, 실패 0
- [x] `git diff --check` 통과

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가? (해당 없음: 테스트·문서만 변경)

## ➕ 추후 계획(선택)

- 복합 unique index의 운영 migration과 canonical seat lock ordering을 별도 Issue에서 함께 검증합니다.
