### PR TITLE
🧪 [TEST] 사용자 취소 신청과 관리자 승인 경합 상태 전이 기준선

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,7 +13,7 @@ BACKLOG는 확정 구현 목록이 아니라 조사와 재현이 필요한 후�
 | 3 | BE | 공통 회차 잔여 좌석 갱신 유실과 checked exception 부분 commit | 결정적 경합·중간 실패 fixture의 개선 후 불변식 | Redis·분산 락 | 완료 ([#5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5), [PR #6](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/6)) |
 | 4 | BE | 복수 좌석의 입력 순서가 달라 deadlock이 발생할 수 있다 | 반대 순서 fixture, index 전후 query plan·첫 lock·DB 예외와 rollback | 무제한 재시도 | lock ordering 완료, migration 중복 기준선 완료 ([#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9), [#11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11), [#15](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/15), [#17](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/17)); 전체 schema baseline 전 운영 index 보류 |
 | 5 | BE/FE | 예약과 결제 완료가 결합되고 상태 전이가 불명확하다 | 현재 흐름 재현, mock 결제, 허용·거부 전이 테스트 | 실제 결제 실행 | 후보 |
-| 6 | BE/FE | 예약·결제·취소 중복 요청의 결과가 안정적이지 않다 | 중복 key, 응답 유실, payload 충돌 fixture | 브로커 선제 도입 | 취소 기준선 완료·개선 진행 ([#21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21), [#31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31)) |
+| 6 | BE/FE | 예약·결제·취소 중복 요청의 결과가 안정적이지 않다 | 중복 key, 응답 유실, payload 충돌 fixture | 브로커 선제 도입 | 관리자 중복 취소 개선 완료·사용자 신청/승인 경합 기준선 진행 ([#21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21), [#31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31), [#33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)) |
 | 7 | BE | 고경합 병목 위치가 측정되지 않았다 | k6 TPS·p95·오류율, lock wait, Hikari, DB 자원 | 운영 SLA 주장 | 후보 |
 | 8 | BE | 비동기·분산 구조의 필요성이 확인되지 않았다 | burst 수용 한계, 이벤트 유실, 독립 재시도 요구 | 기술 시연 목적의 도입 | 보류 |
 

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -16,9 +16,9 @@
 ### Backend Issue #33 — 사용자 취소 신청과 관리자 승인 경합 상태 전이 기준선
 
 - Issue: [#33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)
-- PR: 생성 전
+- PR: [#34](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/34)
 - Branch: `test/33-cancellation-request-approval-race-baseline`
-- 상태: 구현·로컬 검증 완료, PR 준비
+- 상태: 구현·로컬 검증 완료, Backend CI 대기
 - 계획 승인: 완료
 - 구현: 완료
 - 검증: 사용자 조회 완료 → 관리자 승인 commit → 사용자 지연 저장 순서를 latch로 제어해 3회 모두 `취소완료`가 `취소신청`으로 되돌아감을 재현; 좌석 미점유·잔여 24는 유지되고 재승인은 이미 해제된 좌석으로 거부됨; 정상 순차 제어군 포함 대상 15개·전체 Backend 34개 invocation와 `git diff --check` 성공

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -6,27 +6,41 @@
 
 | 구분 | 저장소 | 기준 Branch | 조사 기준 commit |
 | --- | --- | --- | --- |
-| Backend | [TicketOnBoarding_Be](https://github.com/SKUWooU/TicketOnBoarding_Be) | `main` | `bcfa7e30c947975e1f7f89d5eef0e8bffe36b9a1` |
+| Backend | [TicketOnBoarding_Be](https://github.com/SKUWooU/TicketOnBoarding_Be) | `main` | `b10c10727af06cc6fe3f9c8f6813fb3e651a6d7b` |
 | Frontend | [TicketOnBoarding_Fe](https://github.com/SKUWooU/TicketOnBoarding_Fe) | `main` | `1f9678be7a3a66ec610c6ef4ea335e9d6f5cbafd` |
 
 두 저장소는 독립된 Issue와 PR을 사용합니다. 교차 변경은 각 작업의 링크를 양쪽 Issue 또는 PR에 남깁니다.
 
 ## 진행 중
 
+### Backend Issue #33 — 사용자 취소 신청과 관리자 승인 경합 상태 전이 기준선
+
+- Issue: [#33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)
+- PR: 생성 전
+- Branch: `test/33-cancellation-request-approval-race-baseline`
+- 상태: 구현·로컬 검증 완료, PR 준비
+- 계획 승인: 완료
+- 구현: 완료
+- 검증: 사용자 조회 완료 → 관리자 승인 commit → 사용자 지연 저장 순서를 latch로 제어해 3회 모두 `취소완료`가 `취소신청`으로 되돌아감을 재현; 좌석 미점유·잔여 24는 유지되고 재승인은 이미 해제된 좌석으로 거부됨; 정상 순차 제어군 포함 대상 15개·전체 Backend 34개 invocation와 `git diff --check` 성공
+- Reviewer: PR 생성 후 별도 Agent 검토 예정
+- 범위: 기존 사용자 Controller의 분리된 조회·저장 경계와 관리자 잠금 transaction 간 MariaDB Testcontainers 상태 전이 기준선
+- 제외: 운영 로직 수정, 실제 결제·환불·외부 API·Frontend, 전체 상태 enum 전환, k6·분산 lock·대기열·메시지 브로커
+
+## 완료
+
 ### Backend Issue #31 — 취소 중복 요청의 재고 중복 복구 방지
 
 - Issue: [#31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31)
 - PR: [#32](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/32)
 - Branch: `fix/#31-cancellation-idempotency`
-- 상태: 첫 Reviewer Blocking 수정·Backend CI 완료, 재검토 대기
+- squash commit: `b10c10727af06cc6fe3f9c8f6813fb3e651a6d7b`
+- 상태: 완료
 - 계획 승인: 완료
 - 구현: 완료
-- 검증: 대상 11개·전체 30개 invocation 성공, 첫 lock 보유 중 두 번째 lock 조회의 200ms 미반환과 해제 후 완료 확인, 회차 증가 0건 예외 후 예약·좌석 rollback, 없는 예약·이미 해제된 좌석 거부 검증; Blocking 수정 커밋 `47e7f254dd2310a63bdcce0e50dad8ffb1635279` Backend CI 56초 성공
-- Reviewer: HEAD `1add2ad9970b4d6e0349942ef85d12c27d0c54d6`에서 결정적 lock wait·변경 후 실패 rollback 테스트와 진행 상태 동기화 Blocking 확인, 세 항목 수정·CI 성공 후 재검토 대기
+- 검증: 대상 11개·전체 30개 invocation 성공, 첫 lock 보유 중 두 번째 lock 조회의 200ms 미반환과 해제 후 완료 확인, 회차 증가 0건 예외 후 예약·좌석 rollback, 없는 예약·이미 해제된 좌석 거부 검증
+- Reviewer: Blocking 수정 후 최신 HEAD `0edd3d39eaa58a9fdca31a087cddbf2a7b79812b`, Blocking 없음, `MERGE_READY: YES`
 - 범위: 관리자 취소 transaction, 예약 row lock, 취소 상태 정책, 원자적 재고 복구, MariaDB Testcontainers 회귀 테스트
 - 제외: 실제 결제·환불·외부 API·Frontend, 전체 상태 enum 전환, k6·분산 lock·대기열·메시지 브로커
-
-## 완료
 
 ### Backend Issue #29 — auto-merge 연결 Issue 종료 E2E 검증
 

--- a/docs/project-improvement/EVIDENCE_MAP.md
+++ b/docs/project-improvement/EVIDENCE_MAP.md
@@ -22,6 +22,7 @@
 | 동일 예약 순차 중복 취소 | 취소 전 예약 1·점유 좌석 1·잔여 23, 같은 예약 취소 2회, 3회 반복 | 운영 코드 변경 없음 | 예약 상태, 좌석 점유, 잔여 수량, `24 = remaining + reserved` | 매회 `취소완료`·점유 0·잔여 25, 재고 불변식 위반 | [BE #21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21) / [PR #22](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/22) |
 | 취소 요청 상태를 거치지 않은 관리자 취소 | `결제완료` 예약을 관리자 취소 service로 직접 처리 | 운영 코드 변경 없음 | 처리 예외, 최종 예약 상태·좌석·잔여 수량 | 거부 없이 `취소완료`, 점유 0·잔여 24 | [BE #21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21) / [PR #22](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/22) |
 | 동일 예약 중복 취소의 재고 중복 복구 | Issue #21 fixture의 순차 중복과 첫 lock 보유·두 번째 lock 대기 동시 중복 각 3회 | 취소 transaction, 예약 `PESSIMISTIC_WRITE`, 허용 상태 검증, 회차 잔여 원자 증가 | 정상·순차·동시·직접 상태 전이·증가 실패 rollback·없는 예약·해제 좌석, 대상 11개·전체 30개 invocation | 중복 시나리오 잔여 24·불변식 충족, 두 번째 lock은 첫 lock 보유 중 200ms 미반환·해제 후 완료, 실패 경로 상태·재고 보존 | [BE #31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31) |
+| 사용자 중복 취소 신청과 관리자 승인 간 상태 덮어쓰기 | MariaDB 10.11.8, 예약 1·가상 좌석 24개, 사용자 조회 완료 → 관리자 승인 commit → 사용자 지연 저장 순서를 latch로 제어, 3회 반복 | 운영 코드 변경 없음 | 관리자 승인 직후와 사용자 저장 후의 예약 상태·좌석 점유·잔여 수량·재승인 결과, 대상 15개 invocation | 매회 승인 직후 `취소완료`·미점유·잔여 24였으나 사용자 저장 후 `취소신청`·미점유·잔여 24로 상태만 복귀, 재승인은 해제 좌석 오류 | [BE #33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33) |
 | 예약·결제 중복 요청 | 중복 key와 응답 유실 fixture 필요 | 미정 | 결과 재사용, 중복 row, 상태·재고 | 미측정 | 후속 Issue |
 
 ## 기록 규칙

--- a/docs/project-improvement/LEARNING_JOURNEY.md
+++ b/docs/project-improvement/LEARNING_JOURNEY.md
@@ -245,3 +245,23 @@ MariaDB 10.11.8의 공연 1개·회차 1개·가상 좌석 24개 fixture에서 �
 ### 링크
 
 - [Backend Issue #31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31)
+
+## Issue #33 — 사용자 취소 신청과 관리자 승인 경합 상태 전이 기준선
+
+### 조사한 경계
+
+사용자 취소 신청은 Controller가 `findById`로 예약을 읽고 소유자를 확인한 뒤 상태를 `취소신청`으로 바꾸어 별도로 `save`한다. 반면 관리자 승인은 Service transaction에서 같은 예약을 `PESSIMISTIC_WRITE`로 읽고 `취소신청 → 취소완료`, 좌석 해제와 잔여 수량 복구를 함께 commit한다. 사용자 경로의 조회와 저장 전체를 감싸는 transaction이나 예약 row lock은 없다.
+
+### 결정적 재현
+
+MariaDB 10.11.8의 공연 1개·회차 1개·가상 좌석 24개 fixture를 사용했다. 사용자 중복 신청 thread가 `취소신청` 예약을 읽은 직후 latch에서 대기하고, 관리자 실제 취소 Service가 먼저 `취소완료`·좌석 미점유·잔여 24를 commit한 것을 확인한 뒤 사용자 저장을 재개했다. 단순 동시 출발이 아니라 문제가 되는 commit 순서를 강제했으며 동일 조건을 3회 반복했다.
+
+세 번 모두 사용자의 늦은 저장이 예약 상태만 `취소신청`으로 되돌렸다. 좌석은 미점유, 잔여는 24로 재고 수량 불변식 자체는 유지됐지만 관리 화면에는 다시 승인 대상처럼 나타날 수 있고, 같은 관리자 승인 재시도는 이미 해제된 좌석 오류로 거부됐다. 사용자 신청 후 관리자 승인을 순차 실행한 제어군은 최종 `취소완료`를 유지했다.
+
+### 범위와 다음 판단
+
+이는 단일 MariaDB와 가상 좌석에서 현재 repository 호출 순서를 재현한 상태 정합성 기준선이며 운영 환경의 발생 빈도나 처리량을 뜻하지 않는다. 이번 Issue에서는 애플리케이션을 수정하지 않는다. 사용자 취소 신청을 transaction Service로 이동할지, 어떤 상태에서 신청·재신청을 허용할지, 관리자 승인과 같은 예약 lock 순서를 공유할지는 별도 개선 Issue에서 결정한다.
+
+### 링크
+
+- [Backend Issue #33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)

--- a/onticket/src/test/java/com/onticket/concert/service/CancellationConsistencyBaselineIntegrationTest.java
+++ b/onticket/src/test/java/com/onticket/concert/service/CancellationConsistencyBaselineIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -104,6 +105,9 @@ class CancellationConsistencyBaselineIntegrationTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     @MockBean
     private JwtUtil jwtUtil;
@@ -197,6 +201,80 @@ class CancellationConsistencyBaselineIntegrationTest {
     }
 
     @Test
+    void sequentialCancellationRequestThenApprovalEndsWithCompletedCancellation() throws Exception {
+        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow();
+        reservation.setStatus("결제완료");
+        reservationRepository.saveAndFlush(reservation);
+        entityManager.clear();
+
+        requestCancellationLikeMypageController();
+        seatReservationService.cancelReservation(reservationId);
+
+        CancellationSnapshot snapshot = cancellationSnapshot();
+
+        assertThat(snapshot.reservationStatus()).isEqualTo("취소완료");
+        assertThat(snapshot.seatReserved()).isFalse();
+        assertThat(snapshot.remainingSeats()).isEqualTo(TOTAL_SEATS);
+        assertThat(snapshot.inventoryEquationHolds()).isTrue();
+    }
+
+    @RepeatedTest(3)
+    void lateDuplicateCancellationRequestOverwritesCompletedCancellation() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch userReadCompleted = new CountDownLatch(1);
+        CountDownLatch allowUserSave = new CountDownLatch(1);
+
+        try {
+            Future<?> userRequest = executor.submit(() -> {
+                Reservation staleReservation = transactionTemplate.execute(status ->
+                        reservationRepository.findById(reservationId).orElseThrow()
+                );
+                if (staleReservation == null) {
+                    throw new IllegalStateException("사용자 취소 신청 대상 예약을 조회하지 못했습니다.");
+                }
+                if (!"취소신청".equals(staleReservation.getStatus())) {
+                    throw new IllegalStateException("사용자 조회 시점의 예약 상태가 취소신청이 아닙니다.");
+                }
+
+                userReadCompleted.countDown();
+                awaitLatch(allowUserSave, "관리자 승인 이후 사용자 저장 허용 신호");
+
+                staleReservation.setStatus("취소신청");
+                transactionTemplate.executeWithoutResult(status ->
+                        reservationRepository.saveAndFlush(staleReservation)
+                );
+            });
+
+            assertThat(userReadCompleted.await(5, TimeUnit.SECONDS)).isTrue();
+
+            seatReservationService.cancelReservation(reservationId);
+
+            CancellationSnapshot approvedSnapshot = cancellationSnapshot();
+            assertThat(approvedSnapshot.reservationStatus()).isEqualTo("취소완료");
+            assertThat(approvedSnapshot.seatReserved()).isFalse();
+            assertThat(approvedSnapshot.remainingSeats()).isEqualTo(TOTAL_SEATS);
+
+            allowUserSave.countDown();
+            userRequest.get(10, TimeUnit.SECONDS);
+        } finally {
+            allowUserSave.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        CancellationSnapshot snapshot = cancellationSnapshot();
+
+        assertThat(snapshot.reservationStatus()).isEqualTo("취소신청");
+        assertThat(snapshot.seatReserved()).isFalse();
+        assertThat(snapshot.remainingSeats()).isEqualTo(TOTAL_SEATS);
+        assertThat(snapshot.inventoryEquationHolds()).isTrue();
+
+        assertThatThrownBy(() -> seatReservationService.cancelReservation(reservationId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("예약 좌석 상태가 올바르지 않습니다.");
+    }
+
+    @Test
     void inventoryRecoveryFailureRollsBackReservationAndSeat() {
         Reservation reservation = reservationRepository.findById(reservationId).orElseThrow();
         reservation.setConcertTimeId(Long.MAX_VALUE);
@@ -271,6 +349,28 @@ class CancellationConsistencyBaselineIntegrationTest {
             seatReservationService.cancelReservation(reservationId);
         } catch (Exception exception) {
             throw new RuntimeException(exception);
+        }
+    }
+
+    private void requestCancellationLikeMypageController() {
+        Reservation reservation = transactionTemplate.execute(status ->
+                reservationRepository.findById(reservationId).orElseThrow()
+        );
+        if (reservation == null) {
+            throw new IllegalStateException("사용자 취소 신청 대상 예약을 조회하지 못했습니다.");
+        }
+        reservation.setStatus("취소신청");
+        transactionTemplate.executeWithoutResult(status -> reservationRepository.saveAndFlush(reservation));
+    }
+
+    private void awaitLatch(CountDownLatch latch, String description) {
+        try {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException(description + "를 기다리지 못했습니다.");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(description + " 대기 중 interrupt가 발생했습니다.", exception);
         }
     }
 


### PR DESCRIPTION
## 🚀 관련 이슈

- closed #33

## 🧭 변경 타입

- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용

- 사용자 취소 신청의 조회와 저장 사이에 관리자 취소 승인을 commit시키는 결정적 경합 테스트를 추가했습니다.
- 정상 순차 처리와 사용자 지연 저장 경합을 비교하고 예약 상태·좌석 점유·잔여 좌석·재승인 결과를 함께 검증했습니다.
- 확인된 결과와 가상 좌석 fixture의 한계를 개선 근거 문서에 기록했습니다.
- 애플리케이션 코드와 Frontend, README는 변경하지 않았습니다.

## 🔍 기술적 배경

- 사용자 취소 신청은 Controller에서 예약을 조회한 뒤 별도 repository 저장으로 상태를 변경합니다.
- 관리자 승인은 예약 row를 `PESSIMISTIC_WRITE`로 잠그는 Service transaction이지만, 이미 조회된 사용자 엔티티의 늦은 저장까지 막지는 못합니다.
- latch로 사용자 조회 완료 → 관리자 승인 commit → 사용자 저장 순서를 강제한 결과, 승인 완료 상태만 다시 취소 신청으로 덮이는 현상을 3회 재현했습니다.

## 🧪 테스트/검증 (필수)

- [x] `./gradlew.bat test --tests "com.onticket.concert.service.CancellationConsistencyBaselineIntegrationTest"` — 15개 invocation 성공
- [x] `./gradlew.bat test` — 전체 Backend 34개 invocation 성공
- [x] `git diff --check` 성공
- [x] MariaDB 10.11.8 Testcontainers 가상 좌석 fixture만 사용하고 외부 API·결제·운영 데이터를 호출하지 않음

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 외부 동작/응답이 동일함을 확인했는가? — 운영 코드 변경 없음

## ➕ 추후 계획(선택)

- 사용자 취소 신청을 transaction Service로 이동하고 관리자 승인과 예약 잠금·상태 전이 정책을 공유하는 개선은 별도 Issue에서 검토합니다.
