### PR TITLE
🐛 [FIX] 사용자 취소 신청의 잠금·상태 전이 원자성 보장

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,7 +13,7 @@ BACKLOG는 확정 구현 목록이 아니라 조사와 재현이 필요한 후�
 | 3 | BE | 공통 회차 잔여 좌석 갱신 유실과 checked exception 부분 commit | 결정적 경합·중간 실패 fixture의 개선 후 불변식 | Redis·분산 락 | 완료 ([#5](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/5), [PR #6](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/6)) |
 | 4 | BE | 복수 좌석의 입력 순서가 달라 deadlock이 발생할 수 있다 | 반대 순서 fixture, index 전후 query plan·첫 lock·DB 예외와 rollback | 무제한 재시도 | lock ordering 완료, migration 중복 기준선 완료 ([#9](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/9), [#11](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/11), [#15](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/15), [#17](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/17)); 전체 schema baseline 전 운영 index 보류 |
 | 5 | BE/FE | 예약과 결제 완료가 결합되고 상태 전이가 불명확하다 | 현재 흐름 재현, mock 결제, 허용·거부 전이 테스트 | 실제 결제 실행 | 후보 |
-| 6 | BE/FE | 예약·결제·취소 중복 요청의 결과가 안정적이지 않다 | 중복 key, 응답 유실, payload 충돌 fixture | 브로커 선제 도입 | 관리자 중복 취소 개선 완료·사용자 신청/승인 경합 기준선 진행 ([#21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21), [#31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31), [#33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)) |
+| 6 | BE/FE | 예약·결제·취소 중복 요청의 결과가 안정적이지 않다 | 중복 key, 응답 유실, payload 충돌 fixture | 브로커 선제 도입 | 관리자 중복 취소·사용자 신청/승인 경합 개선 완료 ([#21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21), [#31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31), [#33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33), [#35](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/35)) |
 | 7 | BE | 고경합 병목 위치가 측정되지 않았다 | k6 TPS·p95·오류율, lock wait, Hikari, DB 자원 | 운영 SLA 주장 | 후보 |
 | 8 | BE | 비동기·분산 구조의 필요성이 확인되지 않았다 | burst 수용 한계, 이벤트 유실, 독립 재시도 요구 | 기술 시연 목적의 도입 | 보류 |
 

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -6,27 +6,41 @@
 
 | 구분 | 저장소 | 기준 Branch | 조사 기준 commit |
 | --- | --- | --- | --- |
-| Backend | [TicketOnBoarding_Be](https://github.com/SKUWooU/TicketOnBoarding_Be) | `main` | `b10c10727af06cc6fe3f9c8f6813fb3e651a6d7b` |
+| Backend | [TicketOnBoarding_Be](https://github.com/SKUWooU/TicketOnBoarding_Be) | `main` | `87c35225877fc6f49ff597946322b462c856802c` |
 | Frontend | [TicketOnBoarding_Fe](https://github.com/SKUWooU/TicketOnBoarding_Fe) | `main` | `1f9678be7a3a66ec610c6ef4ea335e9d6f5cbafd` |
 
 두 저장소는 독립된 Issue와 PR을 사용합니다. 교차 변경은 각 작업의 링크를 양쪽 Issue 또는 PR에 남깁니다.
 
 ## 진행 중
 
+### Backend Issue #35 — 사용자 취소 신청의 잠금·상태 전이 원자성 보장
+
+- Issue: [#35](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/35)
+- PR: 생성 전
+- Branch: `fix/35-cancellation-request-atomicity`
+- 상태: 구현·로컬 검증 완료, PR 준비
+- 계획 승인: 완료
+- 구현: 완료
+- 검증: 관리자 승인→사용자 신청과 사용자 신청→관리자 승인 양방향에서 두 번째 lock 조회의 200ms 미반환·해제 후 완료를 각 3회 확인, 최종 `취소완료`·미점유·잔여 24 유지; 정상·중복·완료 후 신청·다른 사용자·없는 예약·미지원 상태 Service 통합 23개와 Controller 위임·200·400·401 응답 3개, 전체 Backend 45개 invocation 및 `git diff --check` 성공
+- Reviewer: PR 생성 후 별도 Agent 검토 예정
+- 범위: 사용자 신청 transaction·예약 row lock·소유자 및 상태 정책, Controller Service 위임, Issue #33 회귀 테스트
+- 제외: 실제 결제·환불·외부 API·Frontend, 전체 상태 enum 전환, k6·분산 lock·대기열·메시지 브로커
+
+## 완료
+
 ### Backend Issue #33 — 사용자 취소 신청과 관리자 승인 경합 상태 전이 기준선
 
 - Issue: [#33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)
 - PR: [#34](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/34)
 - Branch: `test/33-cancellation-request-approval-race-baseline`
-- 상태: 구현·로컬 검증 완료, Backend CI 대기
+- squash commit: `87c35225877fc6f49ff597946322b462c856802c`
+- 상태: 완료
 - 계획 승인: 완료
 - 구현: 완료
-- 검증: 사용자 조회 완료 → 관리자 승인 commit → 사용자 지연 저장 순서를 latch로 제어해 3회 모두 `취소완료`가 `취소신청`으로 되돌아감을 재현; 좌석 미점유·잔여 24는 유지되고 재승인은 이미 해제된 좌석으로 거부됨; 정상 순차 제어군 포함 대상 15개·전체 Backend 34개 invocation와 `git diff --check` 성공
-- Reviewer: PR 생성 후 별도 Agent 검토 예정
+- 검증: 사용자 조회 완료 → 관리자 승인 commit → 사용자 지연 저장 순서를 latch로 제어해 3회 모두 `취소완료`가 `취소신청`으로 되돌아감을 재현; 좌석 미점유·잔여 24는 유지되고 재승인은 이미 해제된 좌석으로 거부됨; 정상 순차 제어군 포함 대상 15개·전체 Backend 34개 invocation, Backend CI 2분 5초 성공
+- Reviewer: 최신 HEAD `c7ac32d2e88e1b95712a39e6ef0ee9240bdbd8ae`, Blocking 없음, `MERGE_READY: YES`
 - 범위: 기존 사용자 Controller의 분리된 조회·저장 경계와 관리자 잠금 transaction 간 MariaDB Testcontainers 상태 전이 기준선
 - 제외: 운영 로직 수정, 실제 결제·환불·외부 API·Frontend, 전체 상태 enum 전환, k6·분산 lock·대기열·메시지 브로커
-
-## 완료
 
 ### Backend Issue #31 — 취소 중복 요청의 재고 중복 복구 방지
 

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -16,9 +16,9 @@
 ### Backend Issue #35 — 사용자 취소 신청의 잠금·상태 전이 원자성 보장
 
 - Issue: [#35](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/35)
-- PR: 생성 전
+- PR: [#36](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/36)
 - Branch: `fix/35-cancellation-request-atomicity`
-- 상태: 구현·로컬 검증 완료, PR 준비
+- 상태: 구현·로컬 검증 완료, Backend CI 대기
 - 계획 승인: 완료
 - 구현: 완료
 - 검증: 관리자 승인→사용자 신청과 사용자 신청→관리자 승인 양방향에서 두 번째 lock 조회의 200ms 미반환·해제 후 완료를 각 3회 확인, 최종 `취소완료`·미점유·잔여 24 유지; 정상·중복·완료 후 신청·다른 사용자·없는 예약·미지원 상태 Service 통합 23개와 Controller 위임·200·400·401 응답 3개, 전체 Backend 45개 invocation 및 `git diff --check` 성공

--- a/docs/project-improvement/EVIDENCE_MAP.md
+++ b/docs/project-improvement/EVIDENCE_MAP.md
@@ -23,6 +23,7 @@
 | 취소 요청 상태를 거치지 않은 관리자 취소 | `결제완료` 예약을 관리자 취소 service로 직접 처리 | 운영 코드 변경 없음 | 처리 예외, 최종 예약 상태·좌석·잔여 수량 | 거부 없이 `취소완료`, 점유 0·잔여 24 | [BE #21](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/21) / [PR #22](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/22) |
 | 동일 예약 중복 취소의 재고 중복 복구 | Issue #21 fixture의 순차 중복과 첫 lock 보유·두 번째 lock 대기 동시 중복 각 3회 | 취소 transaction, 예약 `PESSIMISTIC_WRITE`, 허용 상태 검증, 회차 잔여 원자 증가 | 정상·순차·동시·직접 상태 전이·증가 실패 rollback·없는 예약·해제 좌석, 대상 11개·전체 30개 invocation | 중복 시나리오 잔여 24·불변식 충족, 두 번째 lock은 첫 lock 보유 중 200ms 미반환·해제 후 완료, 실패 경로 상태·재고 보존 | [BE #31](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/31) |
 | 사용자 중복 취소 신청과 관리자 승인 간 상태 덮어쓰기 | MariaDB 10.11.8, 예약 1·가상 좌석 24개, 사용자 조회 완료 → 관리자 승인 commit → 사용자 지연 저장 순서를 latch로 제어, 3회 반복 | 운영 코드 변경 없음 | 관리자 승인 직후와 사용자 저장 후의 예약 상태·좌석 점유·잔여 수량·재승인 결과, 대상 15개 invocation | 매회 승인 직후 `취소완료`·미점유·잔여 24였으나 사용자 저장 후 `취소신청`·미점유·잔여 24로 상태만 복귀, 재승인은 해제 좌석 오류 | [BE #33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33) |
+| 사용자 취소 신청의 지연 저장이 관리자 승인 상태를 덮어씀 | Issue #33의 동일 MariaDB·가상 좌석 fixture, 관리자 승인→사용자 신청과 사용자 신청→관리자 승인 lock 순서를 각 3회 반복 | 사용자 신청을 transaction Service로 이동, 예약 `PESSIMISTIC_WRITE`, 소유자·허용 상태 검증, 신청·완료 재시도 성공 재사용 | 양방향 두 번째 lock 조회의 200ms 미반환·해제 후 완료, 최종 예약·좌석·잔여 수량, Service 통합 23개·Controller 3개·전체 45개 invocation | 매회 최종 `취소완료`·미점유·잔여 24 유지, 관리자 재시도도 무변경 성공 | [BE #35](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/35) |
 | 예약·결제 중복 요청 | 중복 key와 응답 유실 fixture 필요 | 미정 | 결과 재사용, 중복 row, 상태·재고 | 미측정 | 후속 Issue |
 
 ## 기록 규칙

--- a/docs/project-improvement/LEARNING_JOURNEY.md
+++ b/docs/project-improvement/LEARNING_JOURNEY.md
@@ -265,3 +265,25 @@ MariaDB 10.11.8의 공연 1개·회차 1개·가상 좌석 24개 fixture를 사�
 ### 링크
 
 - [Backend Issue #33](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/33)
+
+## Issue #35 — 사용자 취소 신청의 잠금·상태 전이 원자성 보장
+
+### 상태 정책과 transaction 경계
+
+사용자 취소 신청의 예약 조회·소유자 확인·상태 변경을 Controller에서 `@Transactional` Service로 이동하고 관리자 승인과 같은 `findByIdWithLock`을 사용한다. `결제완료`만 `취소신청`으로 변경하며 이미 `취소신청`이거나 `취소완료`이면 원하는 결과가 이미 진행 또는 달성된 것으로 보고 변경 없이 성공한다. 다른 사용자, 없는 예약과 알 수 없는 상태는 변경 없이 거부한다.
+
+이 정책은 응답 유실 뒤 같은 요청이 다시 도착해도 상태를 역전시키지 않는다. Controller는 JWT에서 얻은 username과 reservationId를 Service에 위임하고 기존 성공·인증·검증 실패 HTTP 응답을 유지한다.
+
+### 개선 후 경합 검증
+
+Issue #33과 같은 MariaDB 10.11.8·가상 좌석 24개 fixture에서 관리자 승인 transaction이 예약 lock을 획득한 직후 진행을 보류했다. 사용자 신청이 같은 lock 조회에 진입했지만 200ms 동안 반환하지 못하는 것을 확인한 뒤 관리자 transaction을 commit했다. lock을 이어받은 사용자 신청은 최신 `취소완료`를 읽어 변경 없이 성공했다. 반대로 `결제완료` 예약의 사용자 신청이 먼저 lock을 보유한 경우에는 관리자 승인이 대기한 뒤 `취소신청` commit을 이어받아 취소를 완료했다. 두 순서를 각 3회 반복해 최종 `취소완료`·좌석 미점유·잔여 24를 유지했다.
+
+정상 신청과 순차 중복, 취소 완료 후 재요청, 다른 사용자·없는 예약·미지원 상태도 예약·좌석·잔여 수량 snapshot으로 교차 검증했다. Controller 단위 테스트는 인증된 사용자 위임과 기존 200·400·401 응답을 확인했다. Service 통합 23개·Controller 3개와 전체 Backend 45개 test invocation이 통과했다.
+
+### 범위와 한계
+
+동일 예약의 사용자 신청과 관리자 승인 상태 전이만 단일 MariaDB fixture에서 검증했다. 실제 환불 API의 멱등성, 전체 상태 enum 전환, 운영 발생 빈도·처리량과 분산 환경의 lock은 이번 결과에 포함되지 않는다.
+
+### 링크
+
+- [Backend Issue #35](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/35)

--- a/onticket/src/main/java/com/onticket/concert/service/SeatReservationService.java
+++ b/onticket/src/main/java/com/onticket/concert/service/SeatReservationService.java
@@ -24,11 +24,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 @RequiredArgsConstructor
 @Service
 public class SeatReservationService {
 
+    private static final String PAYMENT_COMPLETED = "결제완료";
     private static final String CANCELLATION_REQUESTED = "취소신청";
     private static final String CANCELLATION_COMPLETED = "취소완료";
 
@@ -163,6 +165,25 @@ public class SeatReservationService {
     //관리자페이지-취소신청내약 조회
     public List<Reservation> getCancelList(){
         return reservationRepository.findByStatus("취소신청");
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void requestCancellation(String username, Long reservationId) {
+        Reservation reservation = reservationRepository.findByIdWithLock(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 예약이 없습니다."));
+
+        if (!Objects.equals(reservation.getUsername(), username)) {
+            throw new IllegalArgumentException("예약정보와 다른 사용자입니다.");
+        }
+        if (CANCELLATION_REQUESTED.equals(reservation.getStatus())
+                || CANCELLATION_COMPLETED.equals(reservation.getStatus())) {
+            return;
+        }
+        if (!PAYMENT_COMPLETED.equals(reservation.getStatus())) {
+            throw new IllegalStateException("취소 신청할 수 없는 예약 상태입니다.");
+        }
+
+        reservation.setStatus(CANCELLATION_REQUESTED);
     }
 
     //예매 취소처리

--- a/onticket/src/main/java/com/onticket/user/controller/MypageController.java
+++ b/onticket/src/main/java/com/onticket/user/controller/MypageController.java
@@ -1,25 +1,19 @@
 package com.onticket.user.controller;
 
 import com.onticket.concert.domain.Reservation;
-import com.onticket.concert.repository.ReservationRepository;
-import com.onticket.concert.service.ReviewService;
 import com.onticket.concert.service.SeatReservationService;
 import com.onticket.user.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
 public class MypageController {
     private final SeatReservationService seatReservationService;
-    private final ReservationRepository reservationRepository;
     private final JwtUtil jwtUtil;
 
     //예약조회페이지
@@ -36,16 +30,12 @@ public class MypageController {
     public ResponseEntity<?> cancelReservation(@CookieValue(value = "accessToken", required = false) String token, @PathVariable("reservationId") Long reservationId) {
         if (token != null && jwtUtil.validateToken(token)) {
             String username = jwtUtil.getUsernameFromToken(token);
-            Optional<Reservation> reservation = reservationRepository.findById(reservationId);
-            if (reservation.isPresent()) {
-                Reservation reservation1 = reservation.get();
-                if(!reservation1.getUsername().equals(username)){
-                    return ResponseEntity.badRequest().body("예약정보와 다른 사용자입니다.");
-                }
-                reservation1.setStatus("취소신청");
-                reservationRepository.save(reservation1);
+            try {
+                seatReservationService.requestCancellation(username, reservationId);
                 return ResponseEntity.ok().body("취소신청이 완료되었습니다.");
-            } else return ResponseEntity.badRequest().body("해당하는 예약이 없습니다.");
+            } catch (IllegalArgumentException | IllegalStateException exception) {
+                return ResponseEntity.badRequest().body(exception.getMessage());
+            }
 
         } else return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요한 서비스입니다.");
     }

--- a/onticket/src/test/java/com/onticket/concert/service/CancellationConsistencyBaselineIntegrationTest.java
+++ b/onticket/src/test/java/com/onticket/concert/service/CancellationConsistencyBaselineIntegrationTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -105,9 +104,6 @@ class CancellationConsistencyBaselineIntegrationTest {
 
     @Autowired
     private EntityManager entityManager;
-
-    @Autowired
-    private TransactionTemplate transactionTemplate;
 
     @MockBean
     private JwtUtil jwtUtil;
@@ -207,7 +203,7 @@ class CancellationConsistencyBaselineIntegrationTest {
         reservationRepository.saveAndFlush(reservation);
         entityManager.clear();
 
-        requestCancellationLikeMypageController();
+        seatReservationService.requestCancellation(USERNAME, reservationId);
         seatReservationService.cancelReservation(reservationId);
 
         CancellationSnapshot snapshot = cancellationSnapshot();
@@ -219,59 +215,143 @@ class CancellationConsistencyBaselineIntegrationTest {
     }
 
     @RepeatedTest(3)
-    void lateDuplicateCancellationRequestOverwritesCompletedCancellation() throws Exception {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        CountDownLatch userReadCompleted = new CountDownLatch(1);
-        CountDownLatch allowUserSave = new CountDownLatch(1);
+    void lateCancellationRequestWaitsForApprovalAndKeepsCompletedCancellation() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ReservationLockBarrier barrier = new ReservationLockBarrier();
+        RESERVATION_LOCK_BARRIER.set(barrier);
 
         try {
-            Future<?> userRequest = executor.submit(() -> {
-                Reservation staleReservation = transactionTemplate.execute(status ->
-                        reservationRepository.findById(reservationId).orElseThrow()
-                );
-                if (staleReservation == null) {
-                    throw new IllegalStateException("사용자 취소 신청 대상 예약을 조회하지 못했습니다.");
-                }
-                if (!"취소신청".equals(staleReservation.getStatus())) {
-                    throw new IllegalStateException("사용자 조회 시점의 예약 상태가 취소신청이 아닙니다.");
-                }
+            Future<?> adminApproval = executor.submit(this::cancelReservation);
+            assertThat(barrier.awaitFirstLock()).isTrue();
 
-                userReadCompleted.countDown();
-                awaitLatch(allowUserSave, "관리자 승인 이후 사용자 저장 허용 신호");
+            Future<?> userRequest = executor.submit(() ->
+                    seatReservationService.requestCancellation(USERNAME, reservationId)
+            );
+            assertThat(barrier.awaitSecondLockAttempt()).isTrue();
+            assertThat(barrier.awaitSecondLock(200, TimeUnit.MILLISECONDS)).isFalse();
+            assertThat(adminApproval.isDone()).isFalse();
+            assertThat(userRequest.isDone()).isFalse();
 
-                staleReservation.setStatus("취소신청");
-                transactionTemplate.executeWithoutResult(status ->
-                        reservationRepository.saveAndFlush(staleReservation)
-                );
-            });
-
-            assertThat(userReadCompleted.await(5, TimeUnit.SECONDS)).isTrue();
-
-            seatReservationService.cancelReservation(reservationId);
-
-            CancellationSnapshot approvedSnapshot = cancellationSnapshot();
-            assertThat(approvedSnapshot.reservationStatus()).isEqualTo("취소완료");
-            assertThat(approvedSnapshot.seatReserved()).isFalse();
-            assertThat(approvedSnapshot.remainingSeats()).isEqualTo(TOTAL_SEATS);
-
-            allowUserSave.countDown();
+            barrier.releaseFirstLock();
+            assertThat(barrier.awaitSecondLock(5, TimeUnit.SECONDS)).isTrue();
+            adminApproval.get(10, TimeUnit.SECONDS);
             userRequest.get(10, TimeUnit.SECONDS);
         } finally {
-            allowUserSave.countDown();
+            barrier.releaseFirstLock();
+            RESERVATION_LOCK_BARRIER.set(null);
             executor.shutdownNow();
             assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
         }
 
         CancellationSnapshot snapshot = cancellationSnapshot();
 
-        assertThat(snapshot.reservationStatus()).isEqualTo("취소신청");
+        assertThat(snapshot.reservationStatus()).isEqualTo("취소완료");
         assertThat(snapshot.seatReserved()).isFalse();
         assertThat(snapshot.remainingSeats()).isEqualTo(TOTAL_SEATS);
         assertThat(snapshot.inventoryEquationHolds()).isTrue();
 
-        assertThatThrownBy(() -> seatReservationService.cancelReservation(reservationId))
+        seatReservationService.cancelReservation(reservationId);
+
+        CancellationSnapshot retrySnapshot = cancellationSnapshot();
+        assertThat(retrySnapshot).isEqualTo(snapshot);
+    }
+
+    @RepeatedTest(3)
+    void approvalWaitsForCancellationRequestAndCompletesAfterRequestCommit() throws Exception {
+        updateReservationStatus("결제완료");
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ReservationLockBarrier barrier = new ReservationLockBarrier();
+        RESERVATION_LOCK_BARRIER.set(barrier);
+
+        try {
+            Future<?> userRequest = executor.submit(() ->
+                    seatReservationService.requestCancellation(USERNAME, reservationId)
+            );
+            assertThat(barrier.awaitFirstLock()).isTrue();
+
+            Future<?> adminApproval = executor.submit(this::cancelReservation);
+            assertThat(barrier.awaitSecondLockAttempt()).isTrue();
+            assertThat(barrier.awaitSecondLock(200, TimeUnit.MILLISECONDS)).isFalse();
+            assertThat(userRequest.isDone()).isFalse();
+            assertThat(adminApproval.isDone()).isFalse();
+
+            barrier.releaseFirstLock();
+            assertThat(barrier.awaitSecondLock(5, TimeUnit.SECONDS)).isTrue();
+            userRequest.get(10, TimeUnit.SECONDS);
+            adminApproval.get(10, TimeUnit.SECONDS);
+        } finally {
+            barrier.releaseFirstLock();
+            RESERVATION_LOCK_BARRIER.set(null);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        CancellationSnapshot snapshot = cancellationSnapshot();
+
+        assertThat(snapshot.reservationStatus()).isEqualTo("취소완료");
+        assertThat(snapshot.seatReserved()).isFalse();
+        assertThat(snapshot.remainingSeats()).isEqualTo(TOTAL_SEATS);
+        assertThat(snapshot.inventoryEquationHolds()).isTrue();
+    }
+
+    @Test
+    void duplicateCancellationRequestIsIdempotent() {
+        updateReservationStatus("결제완료");
+
+        seatReservationService.requestCancellation(USERNAME, reservationId);
+        CancellationSnapshot firstSnapshot = cancellationSnapshot();
+        seatReservationService.requestCancellation(USERNAME, reservationId);
+        CancellationSnapshot retrySnapshot = cancellationSnapshot();
+
+        assertThat(firstSnapshot.reservationStatus()).isEqualTo("취소신청");
+        assertThat(firstSnapshot.seatReserved()).isTrue();
+        assertThat(firstSnapshot.remainingSeats()).isEqualTo(TOTAL_SEATS - 1);
+        assertThat(retrySnapshot).isEqualTo(firstSnapshot);
+    }
+
+    @Test
+    void completedCancellationRequestIsIdempotent() throws Exception {
+        seatReservationService.cancelReservation(reservationId);
+        CancellationSnapshot completedSnapshot = cancellationSnapshot();
+
+        seatReservationService.requestCancellation(USERNAME, reservationId);
+
+        assertThat(cancellationSnapshot()).isEqualTo(completedSnapshot);
+    }
+
+    @Test
+    void cancellationRequestByAnotherUserIsRejectedWithoutChange() {
+        updateReservationStatus("결제완료");
+        CancellationSnapshot beforeRequest = cancellationSnapshot();
+
+        assertThatThrownBy(() -> seatReservationService.requestCancellation("another-user", reservationId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("예약정보와 다른 사용자입니다.");
+
+        assertThat(cancellationSnapshot()).isEqualTo(beforeRequest);
+    }
+
+    @Test
+    void missingCancellationRequestIsRejectedWithoutChange() {
+        CancellationSnapshot beforeRequest = cancellationSnapshot();
+
+        assertThatThrownBy(() -> seatReservationService.requestCancellation(USERNAME, Long.MAX_VALUE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당하는 예약이 없습니다.");
+
+        assertThat(cancellationSnapshot()).isEqualTo(beforeRequest);
+    }
+
+    @Test
+    void unsupportedCancellationRequestStateIsRejectedWithoutChange() {
+        updateReservationStatus("알수없음");
+        CancellationSnapshot beforeRequest = cancellationSnapshot();
+
+        assertThatThrownBy(() -> seatReservationService.requestCancellation(USERNAME, reservationId))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("예약 좌석 상태가 올바르지 않습니다.");
+                .hasMessage("취소 신청할 수 없는 예약 상태입니다.");
+
+        assertThat(cancellationSnapshot()).isEqualTo(beforeRequest);
     }
 
     @Test
@@ -352,26 +432,11 @@ class CancellationConsistencyBaselineIntegrationTest {
         }
     }
 
-    private void requestCancellationLikeMypageController() {
-        Reservation reservation = transactionTemplate.execute(status ->
-                reservationRepository.findById(reservationId).orElseThrow()
-        );
-        if (reservation == null) {
-            throw new IllegalStateException("사용자 취소 신청 대상 예약을 조회하지 못했습니다.");
-        }
-        reservation.setStatus("취소신청");
-        transactionTemplate.executeWithoutResult(status -> reservationRepository.saveAndFlush(reservation));
-    }
-
-    private void awaitLatch(CountDownLatch latch, String description) {
-        try {
-            if (!latch.await(10, TimeUnit.SECONDS)) {
-                throw new IllegalStateException(description + "를 기다리지 못했습니다.");
-            }
-        } catch (InterruptedException exception) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException(description + " 대기 중 interrupt가 발생했습니다.", exception);
-        }
+    private void updateReservationStatus(String status) {
+        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow();
+        reservation.setStatus(status);
+        reservationRepository.saveAndFlush(reservation);
+        entityManager.clear();
     }
 
     private CancellationFixture createFixture(String reservationStatus) {

--- a/onticket/src/test/java/com/onticket/user/controller/MypageControllerTest.java
+++ b/onticket/src/test/java/com/onticket/user/controller/MypageControllerTest.java
@@ -1,0 +1,73 @@
+package com.onticket.user.controller;
+
+import com.onticket.concert.service.SeatReservationService;
+import com.onticket.user.jwt.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MypageControllerTest {
+
+    private static final String TOKEN = "valid-token";
+    private static final String USERNAME = "reservation-owner";
+    private static final Long RESERVATION_ID = 1L;
+
+    @Mock
+    private SeatReservationService seatReservationService;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private MypageController mypageController;
+
+    @BeforeEach
+    void setUp() {
+        mypageController = new MypageController(seatReservationService, jwtUtil);
+    }
+
+    @Test
+    void cancellationRequestDelegatesAuthenticatedOwnerToService() {
+        when(jwtUtil.validateToken(TOKEN)).thenReturn(true);
+        when(jwtUtil.getUsernameFromToken(TOKEN)).thenReturn(USERNAME);
+
+        ResponseEntity<?> response = mypageController.cancelReservation(TOKEN, RESERVATION_ID);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("취소신청이 완료되었습니다.");
+        verify(seatReservationService).requestCancellation(USERNAME, RESERVATION_ID);
+    }
+
+    @Test
+    void cancellationRequestReturnsServiceValidationMessageAsBadRequest() {
+        when(jwtUtil.validateToken(TOKEN)).thenReturn(true);
+        when(jwtUtil.getUsernameFromToken(TOKEN)).thenReturn(USERNAME);
+        doThrow(new IllegalArgumentException("예약정보와 다른 사용자입니다."))
+                .when(seatReservationService)
+                .requestCancellation(USERNAME, RESERVATION_ID);
+
+        ResponseEntity<?> response = mypageController.cancelReservation(TOKEN, RESERVATION_ID);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isEqualTo("예약정보와 다른 사용자입니다.");
+    }
+
+    @Test
+    void cancellationRequestWithoutTokenRemainsUnauthorized() {
+        ResponseEntity<?> response = mypageController.cancelReservation(null, RESERVATION_ID);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isEqualTo("로그인이 필요한 서비스입니다.");
+        verifyNoInteractions(seatReservationService);
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈

- closed #35

## 🧭 변경 타입

- [ ] ✨ 기능 추가 (FEAT)
- [x] 🐛 버그 수정 (FIX)
- [x] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용

- 사용자 취소 신청의 조회·소유자 확인·상태 변경을 Controller 직접 저장에서 transaction Service로 이동했습니다.
- 관리자 취소 승인과 동일한 예약 `PESSIMISTIC_WRITE` 잠금을 사용합니다.
- `결제완료 → 취소신청`만 변경하고 `취소신청`·`취소완료` 재요청은 변경 없이 성공하도록 했습니다.
- 다른 사용자·없는 예약·미지원 상태는 DB 변경 없이 거부합니다.
- Issue #33의 결함 재현을 양방향 lock 순서의 개선 후 회귀 테스트로 전환했습니다.

## 🔍 기술적 배경

- 기존 사용자 경로는 repository 조회와 저장 사이에 관리자 승인 transaction이 commit될 수 있어, 늦은 저장이 `취소완료`를 `취소신청`으로 되돌렸습니다.
- 사용자 신청과 관리자 승인이 같은 예약 row를 먼저 잠그면 두 transaction은 최신 상태를 순서대로 읽습니다.
- 관리자 승인→사용자 신청과 사용자 신청→관리자 승인 순서를 각각 강제해 두 번째 요청의 실제 lock wait와 최종 상태를 확인했습니다.

## 🧪 테스트/검증 (필수)

- [x] `./gradlew.bat test --tests "com.onticket.concert.service.CancellationConsistencyBaselineIntegrationTest"` — 23개 invocation 성공
- [x] `./gradlew.bat test --tests "com.onticket.user.controller.MypageControllerTest"` — 3개 성공
- [x] `./gradlew.bat test` — 전체 Backend 45개 invocation 성공
- [x] 양방향 경합 각 3회에서 두 번째 lock 조회가 첫 transaction 보유 중 200ms 미반환, 해제 후 완료
- [x] 최종 `취소완료`·좌석 미점유·잔여 24 및 실패·재시도 후 snapshot 무변경 확인
- [x] `git diff --check` 성공
- [x] 외부 API·결제·운영 데이터 호출 없음

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] (리팩토링인 경우) 기존 성공·검증 실패·인증 실패 HTTP 응답을 확인했는가?

## ➕ 추후 계획(선택)

- 실제 결제·환불의 상태 전이와 중복 요청 멱등성은 mock 결제 기준선부터 별도 Issue로 검증합니다.
