### PR TITLE
🔧 [CHORE] Reviewer 자동 병합 알림과 줄바꿈 정규화

### DIFF
--- a/.github/workflows/reviewer-auto-merge.yml
+++ b/.github/workflows/reviewer-auto-merge.yml
@@ -39,6 +39,7 @@ jobs:
           pr_number="${{ github.event.issue.number }}"
           reviewer="$(jq -r '.comment.user.login' "$GITHUB_EVENT_PATH")"
           body="$(jq -r '.comment.body' "$GITHUB_EVENT_PATH")"
+          body="${body//$'\r'/}"
 
           fail_gate() {
             gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" \
@@ -162,5 +163,8 @@ jobs:
             closed_summary="${closed_issues[*]}"
           fi
 
-          gh pr comment "$pr_number" --repo "$GITHUB_REPOSITORY" \
-            --body "$(printf '## Auto-merge 결과\n\nReviewer 최신 HEAD 승인과 Backend CI 성공을 확인해 squash merge했습니다.\n\n종료한 연결 Issue: %s' "$closed_summary")"
+          {
+            printf '## Auto-merge result\n\n'
+            printf 'PR #%s was squash merged after validating the Reviewer HEAD and Backend CI.\n\n' "$pr_number"
+            printf 'Closed linked issues: %s\n' "$closed_summary"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -22,7 +22,7 @@
 - 계획 승인: 완료
 - 범위: Reviewer 댓글 CRLF 정규화, 성공 시 bot 댓글 제거, 실패 댓글 유지, PR #42 Markdown 댓글 교정
 - 제외: Reviewer의 Blocking/Non-blocking 검토 댓글 제거, 애플리케이션 코드, Frontend
-- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과, Backend CI 1분 33초 성공
+- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과, 최신 HEAD Backend CI 1분 6초 성공
 
 ### Backend Issue #41 — 예약 상태 문자열을 명시적 전이 정책으로 전환
 

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -13,6 +13,16 @@
 
 ## 진행 중
 
+### Backend Issue #45 — Reviewer 자동 병합 알림과 줄바꿈 정규화
+
+- Issue: [#45](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/45)
+- Branch: `chore/45-reviewer-auto-merge-output`
+- 상태: 구현·로컬 검증 완료, PR·CI·Reviewer 대기
+- 계획 승인: 완료
+- 범위: Reviewer 댓글 CRLF 정규화, 성공 시 bot 댓글 제거, 실패 댓글 유지, PR #42 Markdown 댓글 교정
+- 제외: Reviewer의 Blocking/Non-blocking 검토 댓글 제거, 애플리케이션 코드, Frontend
+- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과
+
 ### Backend Issue #41 — 예약 상태 문자열을 명시적 전이 정책으로 전환
 
 - Issue: [#41](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/41)

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -16,12 +16,13 @@
 ### Backend Issue #45 — Reviewer 자동 병합 알림과 줄바꿈 정규화
 
 - Issue: [#45](https://github.com/SKUWooU/TicketOnBoarding_Be/issues/45)
+- PR: [#46](https://github.com/SKUWooU/TicketOnBoarding_Be/pull/46)
 - Branch: `chore/45-reviewer-auto-merge-output`
-- 상태: 구현·로컬 검증 완료, PR·CI·Reviewer 대기
+- 상태: 구현·검증 완료, Reviewer 대기
 - 계획 승인: 완료
 - 범위: Reviewer 댓글 CRLF 정규화, 성공 시 bot 댓글 제거, 실패 댓글 유지, PR #42 Markdown 댓글 교정
 - 제외: Reviewer의 Blocking/Non-blocking 검토 댓글 제거, 애플리케이션 코드, Frontend
-- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과
+- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과, Backend CI 1분 33초 성공
 
 ### Backend Issue #41 — 예약 상태 문자열을 명시적 전이 정책으로 전환
 

--- a/WORK_PROGRESS.md
+++ b/WORK_PROGRESS.md
@@ -22,7 +22,7 @@
 - 계획 승인: 완료
 - 범위: Reviewer 댓글 CRLF 정규화, 성공 시 bot 댓글 제거, 실패 댓글 유지, PR #42 Markdown 댓글 교정
 - 제외: Reviewer의 Blocking/Non-blocking 검토 댓글 제거, 애플리케이션 코드, Frontend
-- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과, 최신 HEAD Backend CI 1분 6초 성공
+- 검증: Git Bash fixture에서 LF·CRLF 입력 통과 및 literal `\\n` 입력 거절, `git diff --check` 통과, 최신 HEAD Backend CI 성공
 
 ### Backend Issue #41 — 예약 상태 문자열을 명시적 전이 정책으로 전환
 


### PR DESCRIPTION
## 🚀 관련 이슈

- closed #45

## 🧭 변경 타입

- [ ] ✨ 기능 추가 (FEAT)
- [ ] 🐛 버그 수정 (FIX)
- [ ] ♻️ 리팩토링 (REFACTOR)
- [x] 🧪 테스트/품질 (TEST/CHORE)

## 📝 작업 내용

- Reviewer 댓글 본문의 CRLF를 LF로 정규화했습니다.
- 정상 squash merge 결과는 PR 댓글 대신 GitHub Actions Job Summary에 기록하도록 변경했습니다.
- 실패·HEAD 변경·연결 Issue 종료 실패 댓글은 유지했습니다.
- PR #42의 literal `\\n` Reviewer 댓글을 실제 Markdown 줄바꿈으로 교정했습니다.

## 🔍 기술적 배경

- Windows에서 수동 작성한 Reviewer 댓글은 CRLF를 포함할 수 있어 `grep -Fqx` 제목 검증에서 정상 제목도 거절됐습니다.
- 성공 시 Reviewer 댓글과 bot 결과 댓글이 연속으로 생성되어 PR 구독자에게 중복 알림이 발생했습니다.

## 🧪 테스트/검증 (필수)

- [x] Git Bash fixture에서 LF·CRLF 입력이 모두 계약 검증을 통과했습니다.
- [x] literal `\\n` 입력은 제목 검증을 통과하지 않음을 확인했습니다.
- [x] `git diff --check`를 통과했습니다.
- [x] PR #42 댓글 API 원문에서 실제 줄바꿈 Markdown을 확인했습니다.

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 애플리케이션 코드와 Frontend 변경이 없는가?
- [x] Reviewer의 Blocking/Non-blocking 검토 댓글은 유지되는가?

## ➕ 추후 계획(선택)

- Issue #45 병합 후 PR #44에 현재 HEAD의 Reviewer 댓글을 다시 생성해 자동 병합 경로를 검증합니다.
